### PR TITLE
Optionally pass aws credentials to s3 module

### DIFF
--- a/notifications_utils/s3.py
+++ b/notifications_utils/s3.py
@@ -7,6 +7,7 @@ from flask import current_app
 
 default_access_key_id = os.environ.get('AWS_ACCESS_KEY_ID')
 default_secret_access_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
+default_region = os.environ.get('AWS_REGION')
 
 
 def s3upload(
@@ -20,7 +21,7 @@ def s3upload(
     access_key=default_access_key_id,
     secret_key=default_secret_access_key,
 ):
-    session = Session(aws_access_key_id=access_key, aws_secret_access_key=secret_key)
+    session = Session(aws_access_key_id=access_key, aws_secret_access_key=secret_key, region_name=region)
     _s3 = session.resource('s3')
 
     key = _s3.Object(bucket_name, file_location)
@@ -51,9 +52,15 @@ class S3ObjectNotFound(botocore.exceptions.ClientError):
     pass
 
 
-def s3download(bucket_name, filename, access_key=default_access_key_id, secret_key=default_secret_access_key):
+def s3download(
+    bucket_name,
+    filename,
+    region=default_region,
+    access_key=default_access_key_id,
+    secret_key=default_secret_access_key,
+):
     try:
-        session = Session(aws_access_key_id=access_key, aws_secret_access_key=secret_key)
+        session = Session(aws_access_key_id=access_key, aws_secret_access_key=secret_key, region_name=region)
         s3 = session.resource('s3')
         key = s3.Object(bucket_name, filename)
         return key.get()['Body']

--- a/notifications_utils/s3.py
+++ b/notifications_utils/s3.py
@@ -1,8 +1,12 @@
+import os
 import urllib
 
 import botocore
-from boto3 import resource
+from boto3 import Session
 from flask import current_app
+
+default_access_key_id = os.environ.get('AWS_ACCESS_KEY_ID')
+default_secret_access_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
 
 
 def s3upload(
@@ -13,8 +17,11 @@ def s3upload(
     content_type='binary/octet-stream',
     tags=None,
     metadata=None,
+    access_key=default_access_key_id,
+    secret_key=default_secret_access_key,
 ):
-    _s3 = resource('s3')
+    session = Session(aws_access_key_id=access_key, aws_secret_access_key=secret_key)
+    _s3 = session.resource('s3')
 
     key = _s3.Object(bucket_name, file_location)
 
@@ -44,9 +51,10 @@ class S3ObjectNotFound(botocore.exceptions.ClientError):
     pass
 
 
-def s3download(bucket_name, filename):
+def s3download(bucket_name, filename, access_key=default_access_key_id, secret_key=default_secret_access_key):
     try:
-        s3 = resource('s3')
+        session = Session(aws_access_key_id=access_key, aws_secret_access_key=secret_key)
+        s3 = session.resource('s3')
         key = s3.Object(bucket_name, filename)
         return key.get()['Body']
     except botocore.exceptions.ClientError as error:

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -13,7 +13,7 @@ content_type = 'binary/octet-stream'
 
 
 def test_s3upload_save_file_to_bucket(mocker):
-    mocked = mocker.patch('notifications_utils.s3.resource')
+    mocked = mocker.patch('notifications_utils.s3.Session.resource')
     s3upload(filedata=contents,
              region=region,
              bucket_name=bucket,
@@ -28,7 +28,7 @@ def test_s3upload_save_file_to_bucket(mocker):
 
 def test_s3upload_save_file_to_bucket_with_contenttype(mocker):
     content_type = 'image/png'
-    mocked = mocker.patch('notifications_utils.s3.resource')
+    mocked = mocker.patch('notifications_utils.s3.Session.resource')
     s3upload(filedata=contents,
              region=region,
              bucket_name=bucket,
@@ -43,7 +43,7 @@ def test_s3upload_save_file_to_bucket_with_contenttype(mocker):
 
 
 def test_s3upload_raises_exception(app, mocker):
-    mocked = mocker.patch('notifications_utils.s3.resource')
+    mocked = mocker.patch('notifications_utils.s3.Session.resource')
     response = {'Error': {'Code': 500}}
     exception = botocore.exceptions.ClientError(response, 'Bad exception')
     mocked.return_value.Object.return_value.put.side_effect = exception
@@ -55,7 +55,7 @@ def test_s3upload_raises_exception(app, mocker):
 
 
 def test_s3upload_save_file_to_bucket_with_urlencoded_tags(mocker):
-    mocked = mocker.patch('notifications_utils.s3.resource')
+    mocked = mocker.patch('notifications_utils.s3.Session.resource')
     s3upload(
         filedata=contents,
         region=region,
@@ -71,7 +71,7 @@ def test_s3upload_save_file_to_bucket_with_urlencoded_tags(mocker):
 
 
 def test_s3upload_save_file_to_bucket_with_metadata(mocker):
-    mocked = mocker.patch('notifications_utils.s3.resource')
+    mocked = mocker.patch('notifications_utils.s3.Session.resource')
     s3upload(
         filedata=contents,
         region=region,
@@ -86,7 +86,7 @@ def test_s3upload_save_file_to_bucket_with_metadata(mocker):
 
 
 def test_s3download_gets_file(mocker):
-    mocked = mocker.patch('notifications_utils.s3.resource')
+    mocked = mocker.patch('notifications_utils.s3.Session.resource')
     mocked_object = mocked.return_value.Object
     mocked_get = mocked.return_value.Object.return_value.get
     s3download('bucket', 'location.file')
@@ -95,7 +95,7 @@ def test_s3download_gets_file(mocker):
 
 
 def test_s3download_raises_on_error(mocker):
-    mocked = mocker.patch('notifications_utils.s3.resource')
+    mocked = mocker.patch('notifications_utils.s3.Session.resource')
     mocked.return_value.Object.side_effect = botocore.exceptions.ClientError(
         {'Error': {'Code': 404}},
         'Bad exception',


### PR DESCRIPTION
This change is needed for using cloud.gov services for s3 buckets. Each bucket will have it's own set of credentials so we need a way to pass credentials that's more flexible than just using `AWS_*` environment variables.