### PR TITLE
Pip audit mitigation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: ./.github/actions/setup-project
       - name: Install application dependencies
         run: make bootstrap
-      - uses: trailofbits/gh-action-pip-audit@v1.0.0
+      - uses: pypa/gh-action-pip-audit@v1.0.4
         with:
           inputs: requirements.txt
           ignore-vulns: PYSEC-2022-237

--- a/.github/workflows/daily_checks.yml
+++ b/.github/workflows/daily_checks.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: ./.github/actions/setup-project
       - name: Install application dependencies
         run: make bootstrap
-      - uses: trailofbits/gh-action-pip-audit@v1.0.0
+      - uses: pypa/gh-action-pip-audit@v1.0.4
         with:
           inputs: requirements.txt
           ignore-vulns: PYSEC-2022-237

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ fix-imports:
 .PHONY: audit
 audit:
 	pip install --upgrade pip-audit
-	pip-audit -r requirements.txt -l --ignore-vuln PYSEC-2022-237
-	-pip-audit -r requirements_for_test.txt -l
+	pip-audit -r requirements.txt --ignore-vuln PYSEC-2022-237
+	-pip-audit -r requirements_for_test.txt
 
 .PHONY: freeze-requirements
 freeze-requirements: ## Pin all requirements including sub dependencies into requirements.txt

--- a/docker-compose.devcontainer.yml
+++ b/docker-compose.devcontainer.yml
@@ -10,4 +10,3 @@ services:
     volumes:
       - .:/workspace:cached
     command: sleep infinity
-    restart: always


### PR DESCRIPTION
Just need to update to most recent action to prevent a false finding.

Also removes the `restart: always` to prevent an unattached devcontainer from being spun up when Docker is launched

closes #19 