### PR TITLE
Default to treating phone numbers as being from the USA

### DIFF
--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -563,7 +563,7 @@ def validate_us_phone_number(number):
     try:
         parsed = phonenumbers.parse(number, "US")
         if not is_us_phone_number(number):
-            raise InvalidPhoneError('Non-US country code')
+            raise InvalidPhoneError('Not a US number')
         if phonenumbers.is_valid_number(parsed):
             return normalize_phone_number(parsed)
         if len(str(parsed.national_number)) > 10:

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -553,7 +553,7 @@ def validate_us_phone_number(number):
     try:
         parsed = phonenumbers.parse(number, "US")
         if parsed.country_code != us_country_code:
-            raise InvalidPhoneError('Non-US county code')
+            raise InvalidPhoneError('Non-US country code')
         if phonenumbers.is_valid_number(parsed):
             return normalize_phone_number(parsed)
         if len(str(parsed.national_number)) > 10:

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,7 @@ mistune==0.8.4
     # via notifications-utils
 orderedset==2.0.3
     # via notifications-utils
-phonenumbers==8.13.2
+phonenumbers==8.13.3
     # via notifications-utils
 pycparser==2.21
     # via cffi

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'statsd>=3.3.0',
         'Flask-Redis>=0.4.0',
         'pyyaml>=5.3.1',
-        'phonenumbers>=8.12.13',
+        'phonenumbers>=8.13.3',
         'pyproj>=3.2.1',
         'pytz>=2020.4',
         'smartypants>=2.0.1',

--- a/tests/test_international_billing_rates.py
+++ b/tests/test_international_billing_rates.py
@@ -34,9 +34,9 @@ def test_country_codes():
 
 
 @pytest.mark.parametrize("number, expected",
-                         [('48123654789', False),  # Poland alpha: Yes
-                          ('1-403-123-5687', True),  # Canada alpha: No
-                          ('40123548897', False),  # Romania alpha: REG
+                         [('+48123654789', False),  # Poland alpha: Yes
+                          ('+1-403-123-5687', True),  # Canada alpha: No
+                          ('+40123548897', False),  # Romania alpha: REG
                           ('+60123451345', True)])  # Malaysia alpha: NO
 def test_use_numeric_sender(number, expected):
     assert use_numeric_sender(number) == expected

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -10,6 +10,7 @@ from orderedset import OrderedSet
 
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.countries import Country
+from notifications_utils.formatters import strip_and_remove_obscure_whitespace
 from notifications_utils.recipients import (
     Cell,
     RecipientCSV,
@@ -277,8 +278,8 @@ def test_get_rows_only_iterates_over_file_once(mocker):
         (
             """
                 phone number,name
-                07700900460, test1
-                +447700 900 460,test2
+                5558675309, test1
+                +1555-867-5301,test2
                 ,
             """,
             'sms',
@@ -351,7 +352,7 @@ def test_get_rows_with_errors():
 
 @pytest.mark.parametrize('template_type, row_count, header, filler, row_with_error', [
     ('email', 500, "email address\n", "test@example.com\n", "test at example dot com"),
-    ('sms', 500, "phone number\n", "07900900123\n", "12345"),
+    ('sms', 500, "phone number\n", "5558675309\n", "12345"),
 ])
 def test_big_list_validates_right_through(template_type, row_count, header, filler, row_with_error):
     big_csv = RecipientCSV(
@@ -393,14 +394,15 @@ def test_check_if_message_too_long_for_sms_but_not_email_in_CSV(
 
 def test_overly_big_list_stops_processing_rows_beyond_max(mocker):
     mock_strip_and_remove_obscure_whitespace = mocker.patch(
-        'notifications_utils.recipients.strip_and_remove_obscure_whitespace'
+        'notifications_utils.recipients.strip_and_remove_obscure_whitespace',
+        wraps=strip_and_remove_obscure_whitespace
     )
     mock_insert_or_append_to_dict = mocker.patch(
         'notifications_utils.recipients.insert_or_append_to_dict'
     )
 
     big_csv = RecipientCSV(
-        "phonenumber,name\n" + ("07700900123,example\n" * 123),
+        "phonenumber,name\n" + ("5558675309,example\n" * 123),
         template=_sample_template('sms', content='hello ((name))'),
     )
     big_csv.max_rows = 10
@@ -556,9 +558,9 @@ def test_get_recipient_respects_order(file_contents,
         (
             """
                 phone number,name
-                07700900460,test1
-                07700900460,test1
-                07700900460,test1
+                5558675309,test1
+                5558675309,test1
+                5558675309,test1
             """,
             'sms',
             ['phone number', 'name'],
@@ -684,11 +686,11 @@ def test_recipient_column(content, file_contents, template_type):
         (
             """
                 phone number,name,date
-                07700900460,test1,test1
-                07700900460,test1
+                5558675309,test1,test1
+                5558675309,test1
                 +44 123,test1,test1
-                07700900460,test1,test1
-                07700900460,test1
+                5558675309,test1,test1
+                5558675309,test1
                 +1644000000,test1,test1
                 ,test1,test1
             """,
@@ -698,7 +700,7 @@ def test_recipient_column(content, file_contents, template_type):
         (
             """
                 phone number,name
-                07700900460,test1,test2
+                5558675309,test1,test2
             """,
             'sms',
             set(), set()
@@ -767,11 +769,11 @@ def test_bad_or_missing_data(
     (
         """
             phone number
-            800000000000
+            +800000000000
             1234
             +447900123
         """,
-        {0, 1, 2},
+        {0, 1},
     ),
     (
         """
@@ -816,24 +818,24 @@ def test_errors_when_too_many_rows():
         (
             """
                 phone number
-                07700900460
-                07700900461
-                07700900462
-                07700900463
+                5558675309
+                5558675301
+                5558675302
+                5558675303
             """,
             'sms',
-            ['+447700900460'],  # Same as first phone number but in different format
+            ['+15558675309'],  # Same as first phone number but in different format
             3
         ),
         (
             """
                 phone number
-                7700900460
-                447700900461
-                07700900462
+                15558675309
+                5558675301
+                5558675302
             """,
             'sms',
-            ['07700900460', '07700900461', '07700900462', '07700900463', 'test@example.com'],
+            ['5558675309', '15558675301', '5558675302', '5551231234', 'test@example.com'],
             0
         ),
         (
@@ -843,7 +845,7 @@ def test_errors_when_too_many_rows():
                 not_in_guestlist@example.com
             """,
             'email',
-            ['in_guestlist@example.com', '07700900460'],  # Email case differs to the one in the CSV
+            ['in_guestlist@example.com', '5558675309'],  # Email case differs to the one in the CSV
             1
         )
     ]
@@ -884,10 +886,10 @@ def test_detects_rows_which_result_in_overly_long_messages():
     recipients = RecipientCSV(
         """
             phone number,placeholder
-            07700900460,1
-            07700900461,{one_under}
-            07700900462,{exactly}
-            07700900463,{one_over}
+            5558675309,1
+            5558675301,{one_under}
+            5558675302,{exactly}
+            5558675303,{one_over}
         """.format(
             one_under='a' * (SMS_CHAR_COUNT_LIMIT - 1),
             exactly='a' * SMS_CHAR_COUNT_LIMIT,
@@ -913,9 +915,9 @@ def test_detects_rows_which_result_in_empty_messages():
     recipients = RecipientCSV(
         """
             phone number,show
-            07700900460,yes
-            07700900462,no
-            07700900463,yes
+            5558675309,yes
+            5558675301,no
+            5558675302,yes
         """,
         template=template
     )
@@ -931,7 +933,7 @@ def test_detects_rows_which_result_in_empty_messages():
     "key, expected",
     sum([
         [(key, expected) for key in group] for expected, group in [
-            ('07700900460', (
+            ('5558675309', (
                 'phone number',
                 '   PHONENUMBER',
                 'phone_number',
@@ -959,14 +961,14 @@ def test_ignores_spaces_and_case_in_placeholders(key, expected):
     recipients = RecipientCSV(
         """
             phone number,FIRSTNAME, Last Name
-            07700900460, Jo, Bloggs
+            5558675309, Jo, Bloggs
         """,
         template=_sample_template('sms', content='((phone_number)) ((First Name)) ((lastname))')
     )
     first_row = recipients[0]
     assert first_row.get(key).data == expected
     assert first_row[key].data == expected
-    assert first_row.recipient == '07700900460'
+    assert first_row.recipient == '5558675309'
     assert len(first_row.items()) == 3
     assert not recipients.has_errors
 
@@ -1021,7 +1023,7 @@ def test_ignores_leading_whitespace_in_file(character, name):
 
 def test_error_if_too_many_recipients():
     recipients = RecipientCSV(
-        'phone number,\n07700900460,\n07700900460,\n07700900460,',
+        'phone number,\n5558675309,\n5558675309,\n5558675309,',
         template=_sample_template('sms'),
         remaining_messages=2
     )
@@ -1031,7 +1033,7 @@ def test_error_if_too_many_recipients():
 
 def test_dont_error_if_too_many_recipients_not_specified():
     recipients = RecipientCSV(
-        'phone number,\n07700900460,\n07700900460,\n07700900460,',
+        'phone number,\n5558675309,\n5558675309,\n5558675309,',
         template=_sample_template('sms'),
     )
     assert not recipients.has_errors
@@ -1094,7 +1096,7 @@ def test_multiple_sms_recipient_columns(international_sms):
     recipients = RecipientCSV(
         """
             phone number, phone number, phone_number, foo
-            07900 900111, 07900 900222, 07900 900333, bar
+            555-867-5301, 555-867-5302, 555-867-5309, bar
         """,
         template=_sample_template('sms'),
         allow_international_sms=international_sms,
@@ -1102,10 +1104,10 @@ def test_multiple_sms_recipient_columns(international_sms):
     assert recipients.column_headers == ['phone number', 'phone_number', 'foo']
     assert recipients.column_headers_as_column_keys == dict(phonenumber='', foo='').keys()
     assert recipients.rows[0].get('phone number').data == (
-        '07900 900333'
+        '555-867-5309'
     )
     assert recipients.rows[0].get('phone_number').data == (
-        '07900 900333'
+        '555-867-5309'
     )
     assert recipients.rows[0].get('phone number').error is None
     assert recipients.duplicate_recipient_column_headers == OrderedSet([
@@ -1311,7 +1313,7 @@ def test_recipient_csv_checks_should_validate_flag(should_validate):
 
     recipients = RecipientCSV(
         """phone number,name
-        07700900460, test1
+        5558675309, test1
         +447700 900 460,test2""",
         template=template,
         should_validate=should_validate

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -278,8 +278,8 @@ def test_get_rows_only_iterates_over_file_once(mocker):
         (
             """
                 phone number,name
-                5558675309, test1
-                +1555-867-5301,test2
+                2348675309, test1
+                +1234-867-5301,test2
                 ,
             """,
             'sms',
@@ -352,7 +352,7 @@ def test_get_rows_with_errors():
 
 @pytest.mark.parametrize('template_type, row_count, header, filler, row_with_error', [
     ('email', 500, "email address\n", "test@example.com\n", "test at example dot com"),
-    ('sms', 500, "phone number\n", "5558675309\n", "12345"),
+    ('sms', 500, "phone number\n", "2348675309\n", "12345"),
 ])
 def test_big_list_validates_right_through(template_type, row_count, header, filler, row_with_error):
     big_csv = RecipientCSV(
@@ -402,7 +402,7 @@ def test_overly_big_list_stops_processing_rows_beyond_max(mocker):
     )
 
     big_csv = RecipientCSV(
-        "phonenumber,name\n" + ("5558675309,example\n" * 123),
+        "phonenumber,name\n" + ("2348675309,example\n" * 123),
         template=_sample_template('sms', content='hello ((name))'),
     )
     big_csv.max_rows = 10
@@ -558,9 +558,9 @@ def test_get_recipient_respects_order(file_contents,
         (
             """
                 phone number,name
-                5558675309,test1
-                5558675309,test1
-                5558675309,test1
+                2348675309,test1
+                2348675309,test1
+                2348675309,test1
             """,
             'sms',
             ['phone number', 'name'],
@@ -686,11 +686,11 @@ def test_recipient_column(content, file_contents, template_type):
         (
             """
                 phone number,name,date
-                5558675309,test1,test1
-                5558675309,test1
+                2348675309,test1,test1
+                2348675309,test1
                 +44 123,test1,test1
-                5558675309,test1,test1
-                5558675309,test1
+                2348675309,test1,test1
+                2348675309,test1
                 +1644000000,test1,test1
                 ,test1,test1
             """,
@@ -700,7 +700,7 @@ def test_recipient_column(content, file_contents, template_type):
         (
             """
                 phone number,name
-                5558675309,test1,test2
+                2348675309,test1,test2
             """,
             'sms',
             set(), set()
@@ -778,9 +778,9 @@ def test_bad_or_missing_data(
     (
         """
             phone number, country
-            1-202-555-0104, USA
-            +12025550104, USA
-            23051234567, Mauritius
+            1-202-234-0104, USA
+            +12022340104, USA
+            +23051234567, Mauritius
         """,
         set(),
     ),
@@ -818,24 +818,24 @@ def test_errors_when_too_many_rows():
         (
             """
                 phone number
-                5558675309
-                5558675301
-                5558675302
-                5558675303
+                2348675309
+                2348675301
+                2348675302
+                2348675303
             """,
             'sms',
-            ['+15558675309'],  # Same as first phone number but in different format
+            ['+12348675309'],  # Same as first phone number but in different format
             3
         ),
         (
             """
                 phone number
-                15558675309
-                5558675301
-                5558675302
+                12348675309
+                2348675301
+                2348675302
             """,
             'sms',
-            ['5558675309', '15558675301', '5558675302', '5551231234', 'test@example.com'],
+            ['2348675309', '12348675301', '2348675302', '2341231234', 'test@example.com'],
             0
         ),
         (
@@ -845,7 +845,7 @@ def test_errors_when_too_many_rows():
                 not_in_guestlist@example.com
             """,
             'email',
-            ['in_guestlist@example.com', '5558675309'],  # Email case differs to the one in the CSV
+            ['in_guestlist@example.com', '2348675309'],  # Email case differs to the one in the CSV
             1
         )
     ]
@@ -886,10 +886,10 @@ def test_detects_rows_which_result_in_overly_long_messages():
     recipients = RecipientCSV(
         """
             phone number,placeholder
-            5558675309,1
-            5558675301,{one_under}
-            5558675302,{exactly}
-            5558675303,{one_over}
+            2348675309,1
+            2348675301,{one_under}
+            2348675302,{exactly}
+            2348675303,{one_over}
         """.format(
             one_under='a' * (SMS_CHAR_COUNT_LIMIT - 1),
             exactly='a' * SMS_CHAR_COUNT_LIMIT,
@@ -915,9 +915,9 @@ def test_detects_rows_which_result_in_empty_messages():
     recipients = RecipientCSV(
         """
             phone number,show
-            5558675309,yes
-            5558675301,no
-            5558675302,yes
+            2348675309,yes
+            2348675301,no
+            2348675302,yes
         """,
         template=template
     )
@@ -933,7 +933,7 @@ def test_detects_rows_which_result_in_empty_messages():
     "key, expected",
     sum([
         [(key, expected) for key in group] for expected, group in [
-            ('5558675309', (
+            ('2348675309', (
                 'phone number',
                 '   PHONENUMBER',
                 'phone_number',
@@ -961,14 +961,14 @@ def test_ignores_spaces_and_case_in_placeholders(key, expected):
     recipients = RecipientCSV(
         """
             phone number,FIRSTNAME, Last Name
-            5558675309, Jo, Bloggs
+            2348675309, Jo, Bloggs
         """,
         template=_sample_template('sms', content='((phone_number)) ((First Name)) ((lastname))')
     )
     first_row = recipients[0]
     assert first_row.get(key).data == expected
     assert first_row[key].data == expected
-    assert first_row.recipient == '5558675309'
+    assert first_row.recipient == '2348675309'
     assert len(first_row.items()) == 3
     assert not recipients.has_errors
 
@@ -1023,7 +1023,7 @@ def test_ignores_leading_whitespace_in_file(character, name):
 
 def test_error_if_too_many_recipients():
     recipients = RecipientCSV(
-        'phone number,\n5558675309,\n5558675309,\n5558675309,',
+        'phone number,\n2348675309,\n2348675309,\n2348675309,',
         template=_sample_template('sms'),
         remaining_messages=2
     )
@@ -1033,7 +1033,7 @@ def test_error_if_too_many_recipients():
 
 def test_dont_error_if_too_many_recipients_not_specified():
     recipients = RecipientCSV(
-        'phone number,\n5558675309,\n5558675309,\n5558675309,',
+        'phone number,\n2348675309,\n2348675309,\n2348675309,',
         template=_sample_template('sms'),
     )
     assert not recipients.has_errors
@@ -1096,7 +1096,7 @@ def test_multiple_sms_recipient_columns(international_sms):
     recipients = RecipientCSV(
         """
             phone number, phone number, phone_number, foo
-            555-867-5301, 555-867-5302, 555-867-5309, bar
+            234-867-5301, 234-867-5302, 234-867-5309, bar
         """,
         template=_sample_template('sms'),
         allow_international_sms=international_sms,
@@ -1104,10 +1104,10 @@ def test_multiple_sms_recipient_columns(international_sms):
     assert recipients.column_headers == ['phone number', 'phone_number', 'foo']
     assert recipients.column_headers_as_column_keys == dict(phonenumber='', foo='').keys()
     assert recipients.rows[0].get('phone number').data == (
-        '555-867-5309'
+        '234-867-5309'
     )
     assert recipients.rows[0].get('phone_number').data == (
-        '555-867-5309'
+        '234-867-5309'
     )
     assert recipients.rows[0].get('phone number').error is None
     assert recipients.duplicate_recipient_column_headers == OrderedSet([
@@ -1313,7 +1313,7 @@ def test_recipient_csv_checks_should_validate_flag(should_validate):
 
     recipients = RecipientCSV(
         """phone number,name
-        5558675309, test1
+        2348675309, test1
         +447700 900 460,test2""",
         template=template,
         should_validate=should_validate

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -8,89 +8,65 @@ from notifications_utils.recipients import (
     format_recipient,
     get_international_phone_info,
     international_phone_info,
-    is_uk_phone_number,
-    normalise_phone_number,
+    is_us_phone_number,
+    normalize_phone_number,
     try_validate_and_format_phone_number,
     validate_and_format_phone_number,
     validate_email_address,
     validate_phone_number,
 )
 
-valid_uk_phone_numbers = [
-    '7123456789',
-    '07123456789',
-    '07123 456789',
-    '07123-456-789',
-    '00447123456789',
-    '00 44 7123456789',
-    '+447123456789',
-    '+44 7123 456 789',
-    '+44 (0)7123 456 789',
-    '\u200B\t\t+44 (0)7123 \uFEFF 456 789 \r\n',
+valid_us_phone_numbers = [
+    '1-202-555-0104',
+    '+12025550104',
+    '12025550104',
+    '(202) 555-0104',
 ]
 
 
 valid_international_phone_numbers = [
     '71234567890',  # Russia
-    '1-202-555-0104',  # USA
-    '+12025550104',  # USA
-    '0012025550104',  # USA
-    '+0012025550104',  # USA
+    '447123456789',  # UK
+    '4407123456789',  # UK
+    '4407123 456789',  # UK
+    '4407123-456-789',  # UK
     '23051234567',  # Mauritius,
     '+682 12345',  # Cook islands
     '+3312345678',
-    '003312345678',
-    '1-2345-12345-12345',  # 15 digits
+    '9-2345-12345-12345',  # 15 digits
 ]
 
 
-valid_phone_numbers = valid_uk_phone_numbers + valid_international_phone_numbers
+valid_phone_numbers = valid_us_phone_numbers + valid_international_phone_numbers
 
 
-invalid_uk_phone_numbers = sum([
+invalid_us_phone_numbers = sum([
     [
         (phone_number, error) for phone_number in group
     ] for error, group in [
         ('Too many digits', (
-            '712345678910',
-            '0712345678910',
-            '0044712345678910',
-            '0044712345678910',
-            '+44 (0)7123 456 789 10',
+            '55512345678',
+            '155512345678',
+            '(555) 1234-5678',
         )),
         ('Not enough digits', (
-            '0712345678',
-            '004471234567',
-            '00447123456',
-            '+44 (0)7123 456 78',
-        )),
-        ('Not a UK mobile number', (
-            '08081 570364',
-            '+44 8081 570364',
-            '0117 496 0860',
-            '+44 117 496 0860',
-            '020 7946 0991',
-            '+44 20 7946 0991',
+            '555123123',
+            '1555123123',
+            '1 (555) 123-123',
         )),
         ('Must not contain letters or symbols', (
-            '07890x32109',
+            '7890x32109',
             '07123 456789...',
             '07123 ☟☜⬇⬆☞☝',
             '07123☟☜⬇⬆☞☝',
             '07";DROP TABLE;"',
-            '+44 07ab cde fgh',
             'ALPHANUM3R1C',
         ))
     ]
 ], [])
 
 
-invalid_phone_numbers = list(filter(
-    lambda number: number[0] not in {
-        '712345678910',   # Could be Russia
-    },
-    invalid_uk_phone_numbers
-)) + [
+invalid_phone_numbers = [
     ('800000000000', 'Not a valid country prefix'),
     ('1234567', 'Not enough digits'),
     ('+682 1234', 'Not enough digits'),  # Cook Islands phone numbers can be 5 digits
@@ -153,68 +129,64 @@ invalid_email_addresses = (
 
 @pytest.mark.parametrize("phone_number", valid_international_phone_numbers)
 def test_detect_international_phone_numbers(phone_number):
-    assert is_uk_phone_number(phone_number) is False
+    assert is_us_phone_number(phone_number) is False
 
 
-@pytest.mark.parametrize("phone_number", valid_uk_phone_numbers)
-def test_detect_uk_phone_numbers(phone_number):
-    assert is_uk_phone_number(phone_number) is True
+@pytest.mark.parametrize("phone_number", valid_us_phone_numbers)
+def test_detect_us_phone_numbers(phone_number):
+    assert is_us_phone_number(phone_number) is True
 
 
 @pytest.mark.parametrize("phone_number, expected_info", [
-    ('07900900123', international_phone_info(
-        international=False,
-        crown_dependency=False,
+    ('4407900900123', international_phone_info(
+        international=True,
         country_prefix='44',  # UK
         billable_units=1,
     )),
-    ('07700900123', international_phone_info(
-        international=False,
-        crown_dependency=False,
+    ('4407700900123', international_phone_info(
+        international=True,
         country_prefix='44',  # Number in TV range
         billable_units=1,
     )),
-    ('07700800123', international_phone_info(
+    ('4407700800123', international_phone_info(
         international=True,
-        crown_dependency=True,
         country_prefix='44',  # UK Crown dependency, so prefix same as UK
         billable_units=1,
     )),
     ('20-12-1234-1234', international_phone_info(
         international=True,
-        crown_dependency=False,
         country_prefix='20',  # Egypt
-        billable_units=3,
+        billable_units=1,
     )),
-    ('00201212341234', international_phone_info(
+    ('201212341234', international_phone_info(
         international=True,
-        crown_dependency=False,
         country_prefix='20',  # Egypt
-        billable_units=3,
+        billable_units=1,
     )),
-    ('1664000000000', international_phone_info(
+    ('16640000000', international_phone_info(
         international=True,
-        crown_dependency=False,
         country_prefix='1664',  # Montserrat
         billable_units=1,
     )),
     ('71234567890', international_phone_info(
         international=True,
-        crown_dependency=False,
         country_prefix='7',  # Russia
         billable_units=1,
     )),
     ('1-202-555-0104', international_phone_info(
-        international=True,
-        crown_dependency=False,
+        international=False,
+        country_prefix='1',  # USA
+        billable_units=1,
+    )),
+    ('202-555-0104', international_phone_info(
+        international=False,
         country_prefix='1',  # USA
         billable_units=1,
     )),
     ('+23051234567', international_phone_info(
         international=True,
-        crown_dependency=False,
         country_prefix='230',  # Mauritius
-        billable_units=2,
+        billable_units=1,
     ))
 ])
 def test_get_international_info(phone_number, expected_info):
@@ -231,16 +203,16 @@ def test_get_international_info(phone_number, expected_info):
     pytest.param('1 2 3 4 5', marks=pytest.mark.xfail),
     pytest.param('(1)2345', marks=pytest.mark.xfail),
 ])
-def test_normalise_phone_number_raises_if_unparseable_characters(phone_number):
+def test_normalize_phone_number_raises_if_unparseable_characters(phone_number):
     with pytest.raises(InvalidPhoneError):
-        normalise_phone_number(phone_number)
+        normalize_phone_number(phone_number)
 
 
 @pytest.mark.parametrize('phone_number', [
     '+21 4321 0987',
     '00997 1234 7890',
-    '801234-7890',
-    '(8-0)-1234-7890',
+    '+801234-7890',
+    '(8-0)-1234-78901',
 ])
 def test_get_international_info_raises(phone_number):
     with pytest.raises(InvalidPhoneError) as error:
@@ -248,7 +220,7 @@ def test_get_international_info_raises(phone_number):
     assert str(error.value) == 'Not a valid country prefix'
 
 
-@pytest.mark.parametrize("phone_number", valid_uk_phone_numbers)
+@pytest.mark.parametrize("phone_number", valid_us_phone_numbers)
 @pytest.mark.parametrize("extra_args", [
     {},
     {'international': False},
@@ -268,17 +240,17 @@ def test_phone_number_accepts_valid_international_values(phone_number):
         pytest.fail('Unexpected InvalidPhoneError')
 
 
-@pytest.mark.parametrize("phone_number", valid_uk_phone_numbers)
-def test_valid_uk_phone_number_can_be_formatted_consistently(phone_number):
-    assert validate_and_format_phone_number(phone_number) == '447123456789'
+@pytest.mark.parametrize("phone_number", valid_us_phone_numbers)
+def test_valid_us_phone_number_can_be_formatted_consistently(phone_number):
+    assert validate_and_format_phone_number(phone_number) == '12025550104'
 
 
 @pytest.mark.parametrize("phone_number, expected_formatted", [
-    ('71234567890', '71234567890'),
+    ('44071234567890', '44071234567890'),
     ('1-202-555-0104', '12025550104'),
     ('+12025550104', '12025550104'),
-    ('0012025550104', '12025550104'),
-    ('+0012025550104', '12025550104'),
+    ('12025550104', '12025550104'),
+    ('+12025550104', '12025550104'),
     ('23051234567', '23051234567'),
 ])
 def test_valid_international_phone_number_can_be_formatted_consistently(phone_number, expected_formatted):
@@ -287,7 +259,7 @@ def test_valid_international_phone_number_can_be_formatted_consistently(phone_nu
     ) == expected_formatted
 
 
-@pytest.mark.parametrize("phone_number, error_message", invalid_uk_phone_numbers)
+@pytest.mark.parametrize("phone_number, error_message", invalid_us_phone_numbers)
 @pytest.mark.parametrize("extra_args", [
     {},
     {'international': False},
@@ -330,15 +302,15 @@ def test_validate_email_address_raises_for_invalid(email_address):
     assert str(e.value) == 'Not a valid email address'
 
 
-@pytest.mark.parametrize("phone_number", valid_uk_phone_numbers)
+@pytest.mark.parametrize("phone_number", valid_us_phone_numbers)
 def test_validates_against_guestlist_of_phone_numbers(phone_number):
-    assert allowed_to_send_to(phone_number, ['07123456789', '07700900460', 'test@example.com'])
-    assert not allowed_to_send_to(phone_number, ['07700900460', '07700900461', 'test@example.com'])
+    assert allowed_to_send_to(phone_number, ['2025550104', '2025550105', 'test@example.com'])
+    assert not allowed_to_send_to(phone_number, ['2025550105', '2028675309', 'test@example.com'])
 
 
 @pytest.mark.parametrize('recipient_number, allowlist_number', [
-    ['1-202-555-0104', '0012025550104'],
-    ['0012025550104', '1-202-555-0104'],
+    ['4407123-456-789', '4407123456789'],
+    ['4407123456789', '4407123-456-789'],
 ])
 def test_validates_against_guestlist_of_international_phone_numbers(recipient_number, allowlist_number):
     assert allowed_to_send_to(recipient_number, [allowlist_number])
@@ -350,18 +322,18 @@ def test_validates_against_guestlist_of_email_addresses(email_address):
 
 
 @pytest.mark.parametrize("phone_number, expected_formatted", [
-    ('07900900123', '07900 900123'),  # UK
-    ('+44(0)7900900123', '07900 900123'),  # UK
-    ('447900900123', '07900 900123'),  # UK
+    ('+4407900900123', '+44 7900 900123'),  # UK
+    ('+44(0)7900900123', '+44 7900 900123'),  # UK
+    ('447900900123', '+44 7900 900123'),  # UK
     ('20-12-1234-1234', '+20 121 234 1234'),  # Egypt
-    ('00201212341234', '+20 121 234 1234'),  # Egypt
+    ('+201212341234', '+20 121 234 1234'),  # Egypt
     ('1664 0000000', '+1 664-000-0000'),  # Montserrat
     ('7 499 1231212', '+7 499 123-12-12'),  # Moscow (Russia)
-    ('1-202-555-0104', '+1 202-555-0104'),  # Washington DC (USA)
+    ('1-202-555-0104', '(202) 555-0104'),  # Washington DC (USA)
     ('+23051234567', '+230 5123 4567'),  # Mauritius
     ('33(0)1 12345678', '+33 1 12 34 56 78'),  # Paris (France)
 ])
-def test_format_uk_and_international_phone_numbers(phone_number, expected_formatted):
+def test_format_us_and_international_phone_numbers(phone_number, expected_formatted):
     assert format_phone_number_human_readable(phone_number) == expected_formatted
 
 
@@ -373,7 +345,7 @@ def test_format_uk_and_international_phone_numbers(phone_number, expected_format
     (None, ''),
     ('foo', 'foo'),
     ('TeSt@ExAmPl3.com', 'test@exampl3.com'),
-    ('+4407900 900 123', '447900900123'),
+    ('+4407900 900 123', '4407900900123'),
     ('+1 800 555 5555', '18005555555'),
 ])
 def test_format_recipient(recipient, expected_formatted):

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -168,8 +168,8 @@ def test_detect_us_phone_numbers(phone_number):
         billable_units=1,
     )),
     ('+1 664-491-3434', international_phone_info(
-        international=False,
-        country_prefix='1',  # Montserrat
+        international=True,
+        country_prefix='1664',  # Montserrat
         billable_units=1,
     )),
     ('+71234567890', international_phone_info(
@@ -316,7 +316,7 @@ def test_validates_against_guestlist_of_email_addresses(email_address):
     ('+447900900123', '+44 7900 900123'),  # UK
     ('+20-12-1234-1234', '+20 121 234 1234'),  # Egypt
     ('+201212341234', '+20 121 234 1234'),  # Egypt
-    ('+1 664 491-3434', '(664) 491-3434'),  # Montserrat
+    ('+1 664 491-3434', '+1 664-491-3434'),  # Montserrat
     ('+7 499 1231212', '+7 499 123-12-12'),  # Moscow (Russia)
     ('1-202-555-0104', '(202) 555-0104'),  # Washington DC (USA)
     ('+23051234567', '+230 5123 4567'),  # Mauritius


### PR DESCRIPTION
Work towards https://github.com/GSA/notifications-api/issues/135

This _may_ need to be updated as I work through API and Admin side changes, but I don't expect it to.

Changes:

* utilize `phonenumbers` library for most parsing, formatting, and validation.
* treat any numbers without a `+` as being US format.
* Remove references to crown dependencies
* Hard-code billing units to `1` until we get a handle on what SNS might cost for international numbers.