### PR TITLE
Add new cache key for overall daily total in Redis

### DIFF
--- a/notifications_utils/clients/redis/__init__.py
+++ b/notifications_utils/clients/redis/__init__.py
@@ -7,5 +7,9 @@ def daily_limit_cache_key(service_id):
     return "{}-{}-{}".format(str(service_id), datetime.utcnow().strftime("%Y-%m-%d"), "count")
 
 
+def daily_total_cache_key():
+    return "{}-{}".format(datetime.utcnow().strftime("%Y-%m-%d"), "total")
+
+
 def rate_limit_cache_key(service_id, api_key_type):
     return "{}-{}".format(str(service_id), api_key_type)

--- a/tests/clients/test_redis.py
+++ b/tests/clients/test_redis.py
@@ -2,6 +2,7 @@ from freezegun import freeze_time
 
 from notifications_utils.clients.redis import (
     daily_limit_cache_key,
+    daily_total_cache_key,
     rate_limit_cache_key,
 )
 
@@ -9,6 +10,11 @@ from notifications_utils.clients.redis import (
 def test_daily_limit_cache_key(sample_service):
     with freeze_time("2016-01-01 12:00:00.000000"):
         assert daily_limit_cache_key(sample_service.id) == '{}-2016-01-01-count'.format(sample_service.id)
+
+
+def test_daily_total_cache_key():
+    with freeze_time("2016-01-01 12:00:00.000000"):
+        assert daily_total_cache_key() == '2016-01-01-total'
 
 
 def test_rate_limit_cache_key(sample_service):


### PR DESCRIPTION
This will be used in the API for limiting our daily total, and in the UI for displaying that total.