### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: pypa/gh-action-pip-audit@v1.0.4
         with:
           inputs: requirements.txt
-          ignore-vulns: GHSA-8fww-64cx-x8p5
 
   static-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily_checks.yml
+++ b/.github/workflows/daily_checks.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: pypa/gh-action-pip-audit@v1.0.4
         with:
           inputs: requirements.txt
-          ignore-vulns: GHSA-8fww-64cx-x8p5
 
   static-scan:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ fix-imports:
 .PHONY: audit
 audit:
 	pip install --upgrade pip-audit
-	pip-audit -r requirements.txt --ignore-vuln GHSA-8fww-64cx-x8p5
+	pip-audit -r requirements.txt
 	-pip-audit -r requirements_for_test.txt
 
 .PHONY: freeze-requirements

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,15 +6,15 @@
 #
 async-timeout==4.0.2
     # via redis
-bleach==5.0.1
+bleach==6.0.0
     # via notifications-utils
-boto3==1.26.25
+boto3==1.26.101
     # via notifications-utils
-botocore==1.29.25
+botocore==1.29.101
     # via
     #   boto3
     #   s3transfer
-cachetools==5.2.0
+cachetools==5.3.0
     # via notifications-utils
 certifi==2022.12.7
     # via
@@ -22,21 +22,21 @@ certifi==2022.12.7
     #   requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via flask
-cryptography==39.0.1
+cryptography==40.0.1
     # via notifications-utils
-flask==2.2.2
+flask==2.2.3
     # via
     #   flask-redis
     #   notifications-utils
 flask-redis==0.4.0
     # via notifications-utils
-geojson==2.5.0
+geojson==3.0.1
     # via notifications-utils
-govuk-bank-holidays==0.11
+govuk-bank-holidays==0.13
     # via notifications-utils
 idna==3.4
     # via requests
@@ -54,39 +54,41 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   jinja2
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
+numpy==1.24.2
+    # via shapely
 orderedset==2.0.3
     # via notifications-utils
-phonenumbers==8.13.3
+phonenumbers==8.13.8
     # via notifications-utils
 pycparser==2.21
     # via cffi
-pypdf2==2.11.2
+pypdf2==3.0.1
     # via notifications-utils
-pyproj==3.4.0
+pyproj==3.5.0
     # via notifications-utils
 python-dateutil==2.8.2
     # via botocore
-python-json-logger==2.0.4
+python-json-logger==2.0.7
     # via notifications-utils
-pytz==2022.6
+pytz==2023.3
     # via notifications-utils
 pyyaml==6.0
     # via notifications-utils
-redis==4.5.3
+redis==4.5.4
     # via flask-redis
-requests==2.28.1
+requests==2.28.2
     # via
     #   govuk-bank-holidays
     #   notifications-utils
 s3transfer==0.6.0
     # via boto3
-shapely==1.8.5.post1
+shapely==2.0.1
     # via notifications-utils
 six==1.16.0
     # via
@@ -98,7 +100,7 @@ statsd==4.0.1
     # via notifications-utils
 typing-extensions==4.5.0
     # via pypdf2
-urllib3==1.26.13
+urllib3==1.26.15
     # via
     #   botocore
     #   requests


### PR DESCRIPTION
Update python dependencies and stop ignoring remediated redis vulnerability.

https://github.com/GSA/notifications-api/issues/217