### PR TITLE
Switch to using FIPS-enabled endpoints

### DIFF
--- a/notifications_utils/s3.py
+++ b/notifications_utils/s3.py
@@ -2,8 +2,8 @@ import os
 import urllib
 
 import botocore
-from botocore.config import Config
 from boto3 import Session
+from botocore.config import Config
 from flask import current_app
 
 AWS_CLIENT_CONFIG = Config(

--- a/notifications_utils/s3.py
+++ b/notifications_utils/s3.py
@@ -35,10 +35,9 @@ def s3upload(
     session = Session(
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
-        region_name=region,
-        config=AWS_CLIENT_CONFIG
+        region_name=region
     )
-    _s3 = session.resource('s3')
+    _s3 = session.resource('s3', config=AWS_CLIENT_CONFIG)
 
     key = _s3.Object(bucket_name, file_location)
 
@@ -79,10 +78,9 @@ def s3download(
         session = Session(
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
-            region_name=region,
-            config=AWS_CLIENT_CONFIG
+            region_name=region
         )
-        s3 = session.resource('s3')
+        s3 = session.resource('s3', config=AWS_CLIENT_CONFIG)
         key = s3.Object(bucket_name, filename)
         return key.get()['Body']
     except botocore.exceptions.ClientError as error:

--- a/notifications_utils/s3.py
+++ b/notifications_utils/s3.py
@@ -35,7 +35,7 @@ def s3upload(
     session = Session(
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
-        region_name=region
+        region_name=region,
         config=AWS_CLIENT_CONFIG
     )
     _s3 = session.resource('s3')


### PR DESCRIPTION
Addresses https://github.com/GSA/notifications-api/issues/274

This changeset switches AWS service touchpoints to use their FIPS-enabled counterparts.  Note that S3 has some specific configuration associated with it.

## Security Considerations

- Helps ensure security compliance of our system by switching to the FIPS-enabled AWS endpoints.