### PR TITLE
Removed refer to daily limit keys

### DIFF
--- a/notifications_utils/__init__.py
+++ b/notifications_utils/__init__.py
@@ -2,7 +2,7 @@ import re
 
 SMS_CHAR_COUNT_LIMIT = 918  # 153 * 6, no network issues but check with providers before upping this further
 LETTER_MAX_PAGE_COUNT = 10
-DAILY_MESSAGE_LIMIT = 5000
+DAILY_MESSAGE_LIMIT = 10000
 
 # regexes for use in recipients.validate_email_address.
 # Valid characters taken from https://en.wikipedia.org/wiki/Email_address#Local-part

--- a/notifications_utils/clients/redis/__init__.py
+++ b/notifications_utils/clients/redis/__init__.py
@@ -9,9 +9,5 @@ def total_limit_cache_key(service_id):
     )
 
 
-def daily_total_cache_key():
-    return "{}-{}".format(datetime.utcnow().strftime("%Y-%m-%d"), "total")
-
-
 def rate_limit_cache_key(service_id, api_key_type):
     return "{}-{}".format(str(service_id), api_key_type)

--- a/tests/clients/test_redis.py
+++ b/tests/clients/test_redis.py
@@ -1,11 +1,6 @@
 from notifications_utils.clients.redis import rate_limit_cache_key
 
 
-from notifications_utils.clients.redis import (
-    rate_limit_cache_key,
-)
-
-
 def test_rate_limit_cache_key(sample_service):
     assert rate_limit_cache_key(sample_service.id, "TEST") == "{}-TEST".format(
         sample_service.id

--- a/tests/clients/test_redis.py
+++ b/tests/clients/test_redis.py
@@ -1,14 +1,9 @@
-from freezegun import freeze_time
+from notifications_utils.clients.redis import rate_limit_cache_key
+
 
 from notifications_utils.clients.redis import (
-    daily_total_cache_key,
     rate_limit_cache_key,
 )
-
-
-def test_daily_total_cache_key():
-    with freeze_time("2016-01-01 12:00:00.000000"):
-        assert daily_total_cache_key() == "2016-01-01-total"
 
 
 def test_rate_limit_cache_key(sample_service):


### PR DESCRIPTION
Removed references to `daily_limit_cache_key()`.

Changed daily retention limit config value from `5000` to `10000`.

Removed tests references `daily_limit_cache_key()`.