### PR TITLE
Allow Notify.gov to use max character sets

### DIFF
--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -38,7 +38,7 @@ class SanitiseText:
         """
         return set(
             c for c in content if c not in cls.ALLOWED_CHARACTERS
-            and not cls.is_hangul(c) and cls.downgrade_character(c) is None)
+            and not cls.is_extended_language(c) and cls.downgrade_character(c) is None)
 
     @staticmethod
     def get_unicode_char_from_codepoint(codepoint):
@@ -76,10 +76,99 @@ class SanitiseText:
             return cls.REPLACEMENT_CHARACTERS.get(c)
 
     @classmethod
-    def is_hangul(cls, value):
+    def is_japanese(cls, value):
+        return_val = False
+        if regex.search(r'\p{IsHan}', value):
+            return_val = True
+        elif regex.search(r'\p{IsHiragana}', value):
+            return_val = True
+        elif regex.search(r'\p{IsKatakana}', value):
+            return_val = True
+        return return_val
+
+    @classmethod
+    def is_extended_language(cls, value):
+        """
+        Some languages are commented out because otherwise the cyclomatic complexity of the method is too high.
+        We will refactor when we get a list of languages we want to support.
+        """
+        return_val = False
         if regex.search(r'\p{IsHangul}', value):
-            return True
-        return False
+            return_val = True
+        elif regex.search(r'\p{IsCyrillic}', value):
+            return_val = True
+        elif regex.search(r'\p{IsArabic}', value):
+            return_val = True
+        elif regex.search(r'\p{IsArmenian}', value):
+            return_val = True
+        elif regex.search(r'\p{IsBengali}', value):
+            return_val = True
+        # elif regex.search(r'\p{IsBuhid}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsCanadian_Aboriginal}', value):
+        #    return_val = True
+        elif regex.search(r'\p{IsCherokee}', value):
+            return_val = True
+        # elif regex.search(r'\p{IsDevanagari}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsEthiopic}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsGeorgian}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsGreek}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsGujarati}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsGurkmukhi}', value):
+        #    return_val = True
+        elif cls.is_japanese(value):
+            return_val = True
+        # elif regex.search(r'\p{IsHanunoo}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsHebrew}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsLimbu}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsKannada}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsKhmer}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsLao}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsMayalayam}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsMongolian}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsMyanmar}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsOgham}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsOriya}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsSinhala}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsSyriac}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsTagalog}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsTagbanwa}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsTaiLe}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsTamil}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsTelugu}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsThaana}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsThai}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsTibetan}', value):
+        #    return_val = True
+        # elif regex.search(r'\p{IsYi}', value):
+        #    return_val = True
+
+        return return_val
 
     @classmethod
     def encode_char(cls, c):
@@ -89,7 +178,7 @@ class SanitiseText:
         # char is a good character already - return that native character.
         if c in cls.ALLOWED_CHARACTERS:
             return c
-        elif cls.is_hangul(c):
+        elif cls.is_extended_language(c):
             return c
         else:
             c = cls.downgrade_character(c)

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -1,7 +1,6 @@
 import ast
 import unicodedata
-
-import regex as regex
+from regex import regex
 
 
 class SanitiseText:

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -1,6 +1,8 @@
 import ast
 import unicodedata
 
+import regex as regex
+
 
 class SanitiseText:
     ALLOWED_CHARACTERS = set()
@@ -72,12 +74,20 @@ class SanitiseText:
             return cls.REPLACEMENT_CHARACTERS.get(c)
 
     @classmethod
+    def is_hangul(cls, value):
+        if regex.search(r'\p{IsHangul}', value):
+            return True
+        return False
+
+    @classmethod
     def encode_char(cls, c):
         """
         Given a single unicode character, return a compatible character from the allowed set.
         """
         # char is a good character already - return that native character.
         if c in cls.ALLOWED_CHARACTERS:
+            return c
+        elif cls.is_hangul(c):
             return c
         else:
             c = cls.downgrade_character(c)

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -1,5 +1,6 @@
 import ast
 import unicodedata
+
 from regex import regex
 
 

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -36,7 +36,9 @@ class SanitiseText:
 
         This follows the same rules as `cls.encode`, but returns just the characters that encode would replace with `?`
         """
-        return set(c for c in content if c not in cls.ALLOWED_CHARACTERS and cls.downgrade_character(c) is None)
+        return set(
+            c for c in content if c not in cls.ALLOWED_CHARACTERS
+            and not cls.is_hangul(c) and cls.downgrade_character(c) is None)
 
     @staticmethod
     def get_unicode_char_from_codepoint(codepoint):

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -77,98 +77,81 @@ class SanitiseText:
 
     @classmethod
     def is_japanese(cls, value):
-        return_val = False
-        if regex.search(r'\p{IsHan}', value):
-            return_val = True
-        elif regex.search(r'\p{IsHiragana}', value):
-            return_val = True
-        elif regex.search(r'\p{IsKatakana}', value):
-            return_val = True
-        return return_val
+        if regex.search(r'([\p{IsHan}\p{IsHiragana}\p{IsKatakana}]+)', value):
+            return True
+        return False
+
+    @classmethod
+    def _is_extended_language_group_one(cls, value):
+        if regex.search(r'\p{IsHangul}', value):  # Korean
+            return True
+        elif regex.search(r'\p{IsCyrillic}', value):
+            return True
+        elif regex.search(r'\p{IsArabic}', value):
+            return True
+        elif regex.search(r'\p{IsArmenian}', value):
+            return True
+        elif regex.search(r'\p{IsBengali}', value):
+            return True
+        return False
+
+    @classmethod
+    def _is_extended_language_group_two(cls, value):
+        if regex.search(r'\p{IsBuhid}', value):
+            return True
+        if regex.search(r'\p{IsCanadian_Aboriginal}', value):
+            return True
+        if regex.search(r'\p{IsCherokee}', value):
+            return True
+        if regex.search(r'\p{IsDevanagari}', value):
+            return True
+        if regex.search(r'\p{IsEthiopic}', value):
+            return True
+        if regex.search(r'\p{IsGeorgian}', value):
+            return True
+        return False
+
+    @classmethod
+    def _is_extended_language_group_three(cls, value):
+
+        if regex.search(r'\p{IsGreek}', value):
+            return True
+        if regex.search(r'\p{IsGujarati}', value):
+            return True
+        if regex.search(r'\p{IsHanunoo}', value):
+            return True
+        if regex.search(r'\p{IsHebrew}', value):
+            return True
+        if regex.search(r'\p{IsLimbu}', value):
+            return True
+        if regex.search(r'\p{IsKannada}', value):
+            return True
+        return False
 
     @classmethod
     def is_extended_language(cls, value):
         """
-        Some languages are commented out because otherwise the cyclomatic complexity of the method is too high.
-        We will refactor when we get a list of languages we want to support.
+        Languages are combined in groups to handle cyclomatic complexity warnings
         """
-        return_val = False
-        if regex.search(r'\p{IsHangul}', value):
-            return_val = True
-        elif regex.search(r'\p{IsCyrillic}', value):
-            return_val = True
-        elif regex.search(r'\p{IsArabic}', value):
-            return_val = True
-        elif regex.search(r'\p{IsArmenian}', value):
-            return_val = True
-        elif regex.search(r'\p{IsBengali}', value):
-            return_val = True
-        # elif regex.search(r'\p{IsBuhid}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsCanadian_Aboriginal}', value):
-        #    return_val = True
-        elif regex.search(r'\p{IsCherokee}', value):
-            return_val = True
-        # elif regex.search(r'\p{IsDevanagari}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsEthiopic}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsGeorgian}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsGreek}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsGujarati}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsGurkmukhi}', value):
-        #    return_val = True
-        elif cls.is_japanese(value):
-            return_val = True
-        # elif regex.search(r'\p{IsHanunoo}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsHebrew}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsLimbu}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsKannada}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsKhmer}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsLao}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsMayalayam}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsMongolian}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsMyanmar}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsOgham}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsOriya}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsSinhala}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsSyriac}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsTagalog}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsTagbanwa}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsTaiLe}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsTamil}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsTelugu}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsThaana}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsThai}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsTibetan}', value):
-        #    return_val = True
-        # elif regex.search(r'\p{IsYi}', value):
-        #    return_val = True
+        if cls._is_extended_language_group_one(value):
+            return True
+        if cls._is_extended_language_group_two(value):
+            return True
+        if cls._is_extended_language_group_three(value):
+            return True
+        if cls.is_japanese(value):
+            return True
 
-        return return_val
+        if regex.search(r'([\p{IsKhmer}\p{IsLao}\p{IsMongolian}\p{IsMyanmar}\p{IsTibetan}\p{IsYi}]+)', value):
+            return True
+
+        if regex.search(r'([\p{IsOgham}\p{IsOriya}\p{IsSinhala}\p{IsSyriac}\p{IsTagalog}]+)', value):
+            return True
+
+        if regex.search(r'([\p{IsTagbanwa}\p{IsTaiLe}\p{IsTamil}\p{IsTelugu}\p{IsThaana}\p{IsThai}]+)', value):
+            return True
+
+        return False
 
     @classmethod
     def encode_char(cls, c):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,22 +4,20 @@
 #
 #    pip-compile requirements.in
 #
--e file:///Users/kkehl/Projects/notifications-utils
-    # via -r requirements.in
 async-timeout==4.0.2
     # via redis
 bleach==6.0.0
-    # via notifications-utils
+    # via sanitized-package
 blinker==1.6.2
     # via flask
 boto3==1.28.24
-    # via notifications-utils
+    # via sanitized-package
 botocore==1.31.24
     # via
     #   boto3
     #   s3transfer
 cachetools==5.3.0
-    # via notifications-utils
+    # via sanitized-package
 certifi==2023.7.22
     # via requests
 cffi==1.15.1
@@ -29,29 +27,27 @@ charset-normalizer==3.1.0
 click==8.1.3
     # via flask
 cryptography==41.0.4
-    # via notifications-utils
+    # via sanitized-package
 flask==2.3.2
     # via
     #   flask-redis
-    #   notifications-utils
+    #   sanitized-package
 flask-redis==0.4.0
-    # via notifications-utils
+    # via sanitized-package
 geojson==3.0.1
-    # via notifications-utils
+    # via sanitized-package
 govuk-bank-holidays==0.13
-    # via notifications-utils
+    # via sanitized-package
 idna==3.4
     # via requests
-importlib-metadata==6.8.0
-    # via flask
 itsdangerous==2.1.2
     # via
     #   flask
-    #   notifications-utils
+    #   sanitized-package
 jinja2==3.1.2
     # via
     #   flask
-    #   notifications-utils
+    #   sanitized-package
 jmespath==1.0.1
     # via
     #   boto3
@@ -61,46 +57,47 @@ markupsafe==2.1.2
     #   jinja2
     #   werkzeug
 mistune==0.8.4
-    # via notifications-utils
+    # via sanitized-package
 numpy==1.24.2
     # via shapely
 orderedset==2.0.3
-    # via notifications-utils
+    # via sanitized-package
 phonenumbers==8.13.8
-    # via notifications-utils
+    # via sanitized-package
 pycparser==2.21
     # via cffi
 python-dateutil==2.8.2
     # via botocore
 python-json-logger==2.0.7
-    # via notifications-utils
+    # via sanitized-package
 pytz==2023.3
-    # via notifications-utils
+    # via sanitized-package
 pyyaml==6.0
-    # via notifications-utils
+    # via sanitized-package
+radon==6.0.1
 redis==4.5.4
     # via flask-redis
+regex==2023.10.3
 requests==2.31.0
     # via
     #   govuk-bank-holidays
-    #   notifications-utils
+    #   sanitized-package
 s3transfer==0.6.1
     # via boto3
 shapely==2.0.1
-    # via notifications-utils
+    # via sanitized-package
 six==1.16.0
     # via
     #   bleach
     #   python-dateutil
 smartypants==2.0.1
-    # via notifications-utils
-urllib3==1.26.17
+    # via sanitized-package
+urllib3==1.26.15
     # via
     #   botocore
     #   requests
+vulture==2.7
 webencodings==0.5.1
     # via bleach
 werkzeug==2.3.3
     # via flask
-zipp==3.17.0
-    # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ six==1.16.0
     #   python-dateutil
 smartypants==2.0.1
     # via sanitized-package
-urllib3==1.26.15
+urllib3==1.26.17
     # via
     #   botocore
     #   requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,20 +4,22 @@
 #
 #    pip-compile requirements.in
 #
+-e file:///Users/kkehl/Projects/notifications-utils
+    # via -r requirements.in
 async-timeout==4.0.2
     # via redis
 bleach==6.0.0
-    # via sanitized-package
+    # via notifications-utils
 blinker==1.6.2
     # via flask
 boto3==1.28.24
-    # via sanitized-package
+    # via notifications-utils
 botocore==1.31.24
     # via
     #   boto3
     #   s3transfer
 cachetools==5.3.0
-    # via sanitized-package
+    # via notifications-utils
 certifi==2023.7.22
     # via requests
 cffi==1.15.1
@@ -27,27 +29,29 @@ charset-normalizer==3.1.0
 click==8.1.3
     # via flask
 cryptography==41.0.4
-    # via sanitized-package
+    # via notifications-utils
 flask==2.3.2
     # via
     #   flask-redis
-    #   sanitized-package
+    #   notifications-utils
 flask-redis==0.4.0
-    # via sanitized-package
+    # via notifications-utils
 geojson==3.0.1
-    # via sanitized-package
+    # via notifications-utils
 govuk-bank-holidays==0.13
-    # via sanitized-package
+    # via notifications-utils
 idna==3.4
     # via requests
+importlib-metadata==6.8.0
+    # via flask
 itsdangerous==2.1.2
     # via
     #   flask
-    #   sanitized-package
+    #   notifications-utils
 jinja2==3.1.2
     # via
     #   flask
-    #   sanitized-package
+    #   notifications-utils
 jmespath==1.0.1
     # via
     #   boto3
@@ -57,47 +61,46 @@ markupsafe==2.1.2
     #   jinja2
     #   werkzeug
 mistune==0.8.4
-    # via sanitized-package
+    # via notifications-utils
 numpy==1.24.2
     # via shapely
 orderedset==2.0.3
-    # via sanitized-package
+    # via notifications-utils
 phonenumbers==8.13.8
-    # via sanitized-package
+    # via notifications-utils
 pycparser==2.21
     # via cffi
 python-dateutil==2.8.2
     # via botocore
 python-json-logger==2.0.7
-    # via sanitized-package
+    # via notifications-utils
 pytz==2023.3
-    # via sanitized-package
+    # via notifications-utils
 pyyaml==6.0
-    # via sanitized-package
-radon==6.0.1
+    # via notifications-utils
 redis==4.5.4
     # via flask-redis
 requests==2.31.0
     # via
     #   govuk-bank-holidays
-    #   sanitized-package
-regex==2023.10.3
+    #   notifications-utils
 s3transfer==0.6.1
     # via boto3
 shapely==2.0.1
-    # via sanitized-package
+    # via notifications-utils
 six==1.16.0
     # via
     #   bleach
     #   python-dateutil
 smartypants==2.0.1
-    # via sanitized-package
+    # via notifications-utils
 urllib3==1.26.17
     # via
     #   botocore
     #   requests
-vulture==2.7
 webencodings==0.5.1
     # via bleach
 werkzeug==2.3.3
     # via flask
+zipp==3.17.0
+    # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,6 +81,7 @@ requests==2.31.0
     # via
     #   govuk-bank-holidays
     #   sanitized-package
+regex==2023.8.8
 s3transfer==0.6.1
     # via boto3
 shapely==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ six==1.16.0
     #   python-dateutil
 smartypants==2.0.1
     # via sanitized-package
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   botocore
     #   requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ requests==2.31.0
     # via
     #   govuk-bank-holidays
     #   sanitized-package
-regex==2023.8.8
+regex==2023.10.3
 s3transfer==0.6.1
     # via boto3
 shapely==2.0.1

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -98,11 +98,12 @@ def test_sms_encoding_get_non_compatible_characters(content, cls, expected):
 
 @pytest.mark.parametrize('content, expected', [
     ('이것은 테스트입니다', True),  # Korean
-    ('Αυτό είναι ένα τεστ', False),  # Greek
+    ('Αυτό είναι ένα τεστ', True),  # Greek
     ('Это проверка', True),  # Russian
-    ('นี่คือการทดสอบ', False),  # Thai
-    ('இது ஒரு சோதனை', False),  # Tamil
-    ('これはテストです', True)  # Japanese
+    ('นี่คือการทดสอบ', True),  # Thai
+    ('இது ஒரு சோதனை', True),  # Tamil
+    ('これはテストです', True),  # Japanese
+    ('Đây là một bài kiểm tra', False)  # Vietnamese
 ])
 def test_sms_supporting_additional_languages(content, expected):
     assert SanitiseSMS.is_extended_language(content) is expected

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -91,6 +91,7 @@ def test_encode_string(content, expected):
     ('Ŵêlsh chârâctêrs ârê cômpâtîblê wîth SanitiseSMS', SanitiseSMS, set()),
     ('Lots of GSM chars that arent ascii compatible:\n\r€', SanitiseSMS, set()),
     ('Lots of GSM chars that arent ascii compatible:\n\r€', SanitiseASCII, {'\n', '\r', '€'}),
+    ('Αυτό είναι ένα τεστ', SanitiseSMS, set())
 ])
 def test_sms_encoding_get_non_compatible_characters(content, cls, expected):
     assert cls.get_non_compatible_characters(content) == expected

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -94,3 +94,15 @@ def test_encode_string(content, expected):
 ])
 def test_sms_encoding_get_non_compatible_characters(content, cls, expected):
     assert cls.get_non_compatible_characters(content) == expected
+
+
+@pytest.mark.parametrize('content, expected', [
+    ('이것은 테스트입니다', True),  # Korean
+    ('Αυτό είναι ένα τεστ', False),  # Greek
+    ('Это проверка', True),  # Russian
+    ('นี่คือการทดสอบ', False),  # Thai
+    ('இது ஒரு சோதனை', False),  # Tamil
+    ('これはテストです', True)  # Japanese
+])
+def test_sms_supporting_additional_languages(content, expected):
+    assert SanitiseSMS.is_extended_language(content) is expected


### PR DESCRIPTION
In order to preserve all the existing anti-XSS logic in the sanitization code, we are going to identify new languages via 'properties' in the regex package.   People have thoughtfully created 45 character sets that correspond to what is allowed in various languages for us to use.

Unfortunately, the list of languages is a mixed bag.  There is support for Korean, Japanese, Russian, Arabic, and various Indian, African, and Southeast Asian languages.   But there is no support for Chinese or Vietnamese, for example.

If we want to extend our language support beyond what is thoughtfully provided in the regex package, we would have to define our own character set ranges for each language, which seems fraught with pitfalls.
