### PR TITLE
Revert "Removed refer to daily limit keys"

### DIFF
--- a/notifications_utils/__init__.py
+++ b/notifications_utils/__init__.py
@@ -2,7 +2,7 @@ import re
 
 SMS_CHAR_COUNT_LIMIT = 918  # 153 * 6, no network issues but check with providers before upping this further
 LETTER_MAX_PAGE_COUNT = 10
-DAILY_MESSAGE_LIMIT = 10000
+DAILY_MESSAGE_LIMIT = 5000
 
 # regexes for use in recipients.validate_email_address.
 # Valid characters taken from https://en.wikipedia.org/wiki/Email_address#Local-part

--- a/notifications_utils/clients/redis/__init__.py
+++ b/notifications_utils/clients/redis/__init__.py
@@ -9,5 +9,9 @@ def total_limit_cache_key(service_id):
     )
 
 
+def daily_total_cache_key():
+    return "{}-{}".format(datetime.utcnow().strftime("%Y-%m-%d"), "total")
+
+
 def rate_limit_cache_key(service_id, api_key_type):
     return "{}-{}".format(str(service_id), api_key_type)

--- a/tests/clients/test_redis.py
+++ b/tests/clients/test_redis.py
@@ -1,4 +1,14 @@
-from notifications_utils.clients.redis import rate_limit_cache_key
+from freezegun import freeze_time
+
+from notifications_utils.clients.redis import (
+    daily_total_cache_key,
+    rate_limit_cache_key,
+)
+
+
+def test_daily_total_cache_key():
+    with freeze_time("2016-01-01 12:00:00.000000"):
+        assert daily_total_cache_key() == "2016-01-01-total"
 
 
 def test_rate_limit_cache_key(sample_service):


### PR DESCRIPTION
Reverts GSA/notifications-utils#56

Until we're able to fully test and merge this capability into the API and Admin repos, we'll need to revert this change.

## Security Considerations

- Reverting this change will allow us to run, restage, and deploy all of the applications.