### PR TITLE
another_test_for_languages

### DIFF
--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -40,7 +40,7 @@ class SanitiseText:
             c
             for c in content
             if c not in cls.ALLOWED_CHARACTERS
-            and not cls.is_extended_language(c)
+            and cls.is_extended_language(c) is False
             and cls.downgrade_character(c) is None
         )
 

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -145,3 +145,19 @@ def test_sms_encoding_get_non_compatible_characters(content, cls, expected):
 )
 def test_sms_supporting_additional_languages(content, expected):
     assert SanitiseSMS.is_extended_language(content) is expected
+
+
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        ("이것은 테스트입니다", set()),  # Korean
+        ("Αυτό είναι ένα τεστ", set()),  # Greek
+        ("Это проверка", set()),  # Russian
+        ("นี่คือการทดสอบ", set()),  # Thai
+        ("இது ஒரு சோதனை", set()),  # Tamil
+        ("これはテストです", set()),  # Japanese
+        ("Đây là một bài kiểm tra", set("Đ")),  # Vietnamese
+    ],
+)
+def test_get_non_compatible_characters(content, expected):
+    assert SanitiseSMS.get_non_compatible_characters(content) == expected


### PR DESCRIPTION
Right now notifications-admin is failing because the call to SanitiseSMS.get_non_compatible_characters() is returning characters (for example, Korean) when it should be returning nothing.  This additional test shows notification_utils is working properly and allowing new languages to go through the sanitation checks.

I'm wondering how do we know which version of notification_utils notification_admin is using?