### PR TITLE
Improve poetry usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 
 .PHONY: bootstrap
 bootstrap: ## Build project
-	poetry install
+	poetry install --sync
 
 .PHONY: dead-code
 dead-code:
@@ -59,6 +59,7 @@ audit:
 .PHONY: py-lock
 py-lock: ## Syncs dependencies and updates lock file without performing recursive internal updates
 	poetry lock --no-update
+	poetry install --sync
 
 .PHONY: freeze-requirements
 freeze-requirements: ## Pin all requirements including sub dependencies into requirements.txt
@@ -75,12 +76,12 @@ reset-version:
 
 .PHONY: version-major
 version-major: reset-version ## Update the major version number
-	./scripts/bump_version.py major
+	poetry run python scripts/bump_version.py major
 
 .PHONY: version-minor
 version-minor: reset-version ## Update the minor version number
-	./scripts/bump_version.py minor
+	poetry run python scripts/bump_version.py minor
 
 .PHONY: version-patch
 version-patch: reset-version ## Update the patch version number
-	./scripts/bump_version.py patch
+	poetry run python scripts/bump_version.py patch

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Run one of the following `Makefile` commands, depending on the need:
 - `make version-patch`
 
 The output will tell you how to update the dependency reference for the other
-repos the rely on this one.
+repos that rely on this one.
 
 ## License && public domain
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ make bootstrap
 make test
 ```
 
-## To sync your poetry.lock file after manual pyproject.toml edits
+## To sync your poetry.lock file and dependencies after manual pyproject.toml edits
 
 ```
 # run the make command
@@ -43,6 +43,17 @@ This will tell Poetry to do the following:
 - Look for the latest compatible version of the dependency/dependencies
 - Install the version(s) it finds
 - Update and sync the poetry.lock file
+
+## To update the version of this library
+
+Run one of the following `Makefile` commands, depending on the need:
+
+- `make version-major`
+- `make version-minor`
+- `make version-patch`
+
+The output will tell you how to update the dependency reference for the other
+repos the rely on this one.
 
 ## License && public domain
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '57.0.0'  # 2e6a4b3a798e337102bca0e18340b617
+__version__ = '57.0.0'  # 19648fb5bface606f592520eec6b6409

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "56.0.3"  # 149a7a20b681eeccda6fda65be37a3fb
+__version__ = '57.0.0'  # 2e6a4b3a798e337102bca0e18340b617

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -69,7 +69,7 @@ print("   Update requirements files in other apps with:")
 print("")
 print(
     f"   "
-    f"notifications-utils @ git+https://github.com/alphagov/notifications-utils.git"
+    f"notifications-utils @ git+https://github.com/GSA/notifications-utils.git"
     f"@{new_major}.{new_minor}.{new_patch}"
 )
 print("")


### PR DESCRIPTION
This changeset modifies a few of the Makefile commands:
    
- Modifies and adds `poetry install --sync` to help update the virtual environment properly, especially after a lock
- Fixes the version bump commands
    
It also bumps the version of the utils repo to `57.0.0` to help with ensuring the latest version gets pulled down.

## Security Considerations

- We're making sure our repos stay up-to-date with their dependencies properly.