### PR TITLE
notify-admin-943 don't support international phone numbers

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -143,9 +143,7 @@ def create_sanitised_html_for_url(link, *, classes="", style=""):
     class_attribute = f'class="{classes}" ' if classes else ""
     style_attribute = f'style="{style}" ' if style else ""
 
-    return (
-        '<a {}{}href="{}">{}</a>'
-    ).format(
+    return ('<a {}{}href="{}">{}</a>').format(
         class_attribute,
         style_attribute,
         urllib.parse.quote(urllib.parse.unquote(link), safe=":/?#=&;"),

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -610,6 +610,8 @@ def validate_phone_number(number, international=False):
 
     try:
         parsed = phonenumbers.parse(number, None)
+        if parsed.country_code != 1:
+            raise InvalidPhoneError("Invalid country code")
         number = f"{parsed.country_code}{parsed.national_number}"
         if len(number) < 8:
             raise InvalidPhoneError("Not enough digits")

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -476,38 +476,31 @@ def test_normalise_whitespace(value):
         ),
         (
             "Go to gov.uk/example.",
-            'Go to '
-            '<a href="http://gov.uk/example">Join Service</a>.',
+            "Go to " '<a href="http://gov.uk/example">Join Service</a>.',
         ),
         (
             "Go to gov.uk/example:",
-            'Go to '
-            '<a href="http://gov.uk/example">Join Service</a>:',
+            "Go to " '<a href="http://gov.uk/example">Join Service</a>:',
         ),
         (
             "Go to gov.uk/example;",
-            'Go to '
-            '<a href="http://gov.uk/example;">Join Service</a>',
+            "Go to " '<a href="http://gov.uk/example;">Join Service</a>',
         ),
         (
             "(gov.uk/example)",
-            '('
-            '<a href="http://gov.uk/example">Join Service</a>)',
+            "(" '<a href="http://gov.uk/example">Join Service</a>)',
         ),
         (
             "(gov.uk/example)...",
-            '('
-            '<a href="http://gov.uk/example">Join Service</a>)...',
+            "(" '<a href="http://gov.uk/example">Join Service</a>)...',
         ),
         (
             "(gov.uk/example.)",
-            '('
-            '<a href="http://gov.uk/example">Join Service</a>.)',
+            "(" '<a href="http://gov.uk/example">Join Service</a>.)',
         ),
         (
             "(see example.com/foo_(bar))",
-            '(see '
-            '<a href="http://example.com/foo_%28bar%29">Join Service</a>)',
+            "(see " '<a href="http://example.com/foo_%28bar%29">Join Service</a>)',
         ),
         (
             "example.com/foo(((((((bar",
@@ -515,13 +508,12 @@ def test_normalise_whitespace(value):
         ),
         (
             "government website (gov.uk). Other websites…",
-            'government website ('
+            "government website ("
             '<a href="http://gov.uk">Join Service</a>). Other websites…',
         ),
         (
             "[gov.uk/example]",
-            '['
-            '<a href="http://gov.uk/example">Join Service</a>]',
+            "[" '<a href="http://gov.uk/example">Join Service</a>]',
         ),
         (
             "gov.uk/foo, gov.uk/bar",
@@ -530,8 +522,7 @@ def test_normalise_whitespace(value):
         ),
         (
             "<p>gov.uk/foo</p>",
-            '<p>'
-            '<a href="http://gov.uk/foo">Join Service</a></p>',
+            "<p>" '<a href="http://gov.uk/foo">Join Service</a></p>',
         ),
         (
             "gov.uk?foo&amp;",

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -48,9 +48,9 @@ def test_makes_links_out_of_URLs(url):
             ("this link is in brackets (http://example.com)"),
             (
                 "this link is in brackets "
-                '('
+                "("
                 '<a style="word-wrap: break-word; color: #1D70B8;" href="http://example.com">'
-                'Join Service</a>)'
+                "Join Service</a>)"
             ),
         ),
     ],
@@ -464,7 +464,7 @@ def test_table(markdown_function):
             (
                 '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
                 '<a style="word-wrap: break-word; color: #1D70B8;" href="http://example.com">'
-                'Join Service</a>'
+                "Join Service</a>"
                 "</p>"
             ),
         ],
@@ -475,7 +475,7 @@ def test_table(markdown_function):
                 '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
                 '<a style="word-wrap: break-word; color: #1D70B8;" '
                 'href="https://example.com%22onclick=%22alert%28%27hi">'
-                'Join Service'
+                "Join Service"
                 "</a>')"
                 "</p>"
             ),

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -770,7 +770,7 @@ def test_bad_or_missing_data(
             1234
             +447900123
         """,
-            {0, 1},
+            {0, 1, 2},
         ),
         (
             """
@@ -779,7 +779,7 @@ def test_bad_or_missing_data(
             +12022340104, USA
             +23051234567, Mauritius
         """,
-            set(),
+            {2},
         ),
     ],
 )

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -23,17 +23,21 @@ valid_us_phone_numbers = [
     "(202) 555-0104",
 ]
 
+# TODO
+# International phone number tests are commented out as a result of issue #943 in notifications-admin.  We are
+# deliberately eliminating the ability to send to numbers outside of country code 1.   These tests should
+# be removed at some point when we are sure we are never going to support international numbers
 
 valid_international_phone_numbers = [
-    "+71234567890",  # Russia
-    "+447123456789",  # UK
-    "+4407123456789",  # UK
-    "+4407123 456789",  # UK
-    "+4407123-456-789",  # UK
-    "+23051234567",  # Mauritius,
-    "+682 12345",  # Cook islands
-    "+3312345678",
-    "+9-2345-12345-12345",  # 15 digits
+    # "+71234567890",  # Russia
+    # "+447123456789",  # UK
+    # "+4407123456789",  # UK
+    # "+4407123 456789",  # UK
+    # "+4407123-456-789",  # UK
+    # "+23051234567",  # Mauritius,
+    # "+682 12345",  # Cook islands
+    # "+3312345678",
+    # "+9-2345-12345-12345",  # 15 digits
 ]
 
 
@@ -80,7 +84,7 @@ invalid_us_phone_numbers = sum(
 invalid_phone_numbers = [
     ("+80233456789", "Not a valid country prefix"),
     ("1234567", "Not enough digits"),
-    ("+682 1234", "Not enough digits"),  # Cook Islands phone numbers can be 5 digits
+    ("+682 1234", "Invalid country code"),  # Cook Islands phone numbers can be 5 digits
     ("+12345 12345 12345 6", "Too many digits"),
 ]
 
@@ -151,46 +155,46 @@ def test_detect_us_phone_numbers(phone_number):
 @pytest.mark.parametrize(
     "phone_number, expected_info",
     [
-        (
-            "+4407900900123",
-            international_phone_info(
-                international=True,
-                country_prefix="44",  # UK
-                billable_units=1,
-            ),
-        ),
-        (
-            "+4407700900123",
-            international_phone_info(
-                international=True,
-                country_prefix="44",  # Number in TV range
-                billable_units=1,
-            ),
-        ),
-        (
-            "+4407700800123",
-            international_phone_info(
-                international=True,
-                country_prefix="44",  # UK Crown dependency, so prefix same as UK
-                billable_units=1,
-            ),
-        ),
-        (
-            "+20-12-1234-1234",
-            international_phone_info(
-                international=True,
-                country_prefix="20",  # Egypt
-                billable_units=1,
-            ),
-        ),
-        (
-            "+201212341234",
-            international_phone_info(
-                international=True,
-                country_prefix="20",  # Egypt
-                billable_units=1,
-            ),
-        ),
+        # (
+        #    "+4407900900123",
+        #    international_phone_info(
+        #        international=True,
+        #        country_prefix="44",  # UK
+        #        billable_units=1,
+        #    ),
+        # ),
+        # (
+        #    "+4407700900123",
+        #    international_phone_info(
+        #        international=True,
+        #        country_prefix="44",  # Number in TV range
+        #        billable_units=1,
+        #    ),
+        # ),
+        # (
+        #    "+4407700800123",
+        #    international_phone_info(
+        #        international=True,
+        #        country_prefix="44",  # UK Crown dependency, so prefix same as UK
+        #        billable_units=1,
+        #    ),
+        # ),
+        # ( #
+        #    "+20-12-1234-1234",
+        #    international_phone_info(
+        #        international=True,
+        #        country_prefix="20",  # Egypt
+        #        billable_units=1,
+        #    ),
+        # ),
+        # (
+        #    "+201212341234",
+        #    international_phone_info(
+        #        international=True,
+        #        country_prefix="20",  # Egypt
+        #        billable_units=1,
+        #    ),
+        # ),
         (
             "+1 664-491-3434",
             international_phone_info(
@@ -199,14 +203,14 @@ def test_detect_us_phone_numbers(phone_number):
                 billable_units=1,
             ),
         ),
-        (
-            "+71234567890",
-            international_phone_info(
-                international=True,
-                country_prefix="7",  # Russia
-                billable_units=1,
-            ),
-        ),
+        # (
+        #    "+71234567890",
+        #    international_phone_info(
+        #        international=True,
+        #        country_prefix="7",  # Russia
+        #        billable_units=1,
+        #    ),
+        # ),
         (
             "1-202-555-0104",
             international_phone_info(
@@ -223,14 +227,14 @@ def test_detect_us_phone_numbers(phone_number):
                 billable_units=1,
             ),
         ),
-        (
-            "+23051234567",
-            international_phone_info(
-                international=True,
-                country_prefix="230",  # Mauritius
-                billable_units=1,
-            ),
-        ),
+        # (
+        #    "+23051234567",
+        #    international_phone_info(
+        #        international=True,
+        #        country_prefix="230",  # Mauritius
+        #        billable_units=1,
+        #    ),
+        # ),
     ],
 )
 def test_get_international_info(phone_number, expected_info):
@@ -283,12 +287,12 @@ def test_valid_us_phone_number_can_be_formatted_consistently(phone_number):
 @pytest.mark.parametrize(
     "phone_number, expected_formatted",
     [
-        ("+44071234567890", "+4471234567890"),
+        # ("+44071234567890", "+4471234567890"),
         ("1-202-555-0104", "+12025550104"),
         ("+12025550104", "+12025550104"),
         ("12025550104", "+12025550104"),
         ("+12025550104", "+12025550104"),
-        ("+23051234567", "+23051234567"),
+        # ("+23051234567", "+23051234567"),
     ],
 )
 def test_valid_international_phone_number_can_be_formatted_consistently(
@@ -359,17 +363,17 @@ def test_validates_against_guestlist_of_phone_numbers(phone_number):
     )
 
 
-@pytest.mark.parametrize(
-    "recipient_number, allowlist_number",
-    [
-        ["+4407123-456-789", "+4407123456789"],
-        ["+4407123456789", "+4407123-456-789"],
-    ],
-)
-def test_validates_against_guestlist_of_international_phone_numbers(
-    recipient_number, allowlist_number
-):
-    assert allowed_to_send_to(recipient_number, [allowlist_number])
+# @pytest.mark.parametrize(
+#    "recipient_number, allowlist_number",
+#    [
+#        ["+4407123-456-789", "+4407123456789"],
+#        ["+4407123456789", "+4407123-456-789"],
+#    ],
+# )
+# def test_validates_against_guestlist_of_international_phone_numbers(
+#    recipient_number, allowlist_number
+# ):
+#    assert allowed_to_send_to(recipient_number, [allowlist_number])
 
 
 @pytest.mark.parametrize("email_address", valid_email_addresses)
@@ -382,16 +386,16 @@ def test_validates_against_guestlist_of_email_addresses(email_address):
 @pytest.mark.parametrize(
     "phone_number, expected_formatted",
     [
-        ("+4407900900123", "+44 7900 900123"),  # UK
-        ("+44(0)7900900123", "+44 7900 900123"),  # UK
-        ("+447900900123", "+44 7900 900123"),  # UK
+        # ("+4407900900123", "+44 7900 900123"),  # UK
+        # ("+44(0)7900900123", "+44 7900 900123"),  # UK
+        # ("+447900900123", "+44 7900 900123"),  # UK
         # ("+20-12-1234-1234", "+20 121 234 1234"),  # Egypt
         # ("+201212341234", "+20 121 234 1234"),  # Egypt
         ("+1 664 491-3434", "+1 664-491-3434"),  # Montserrat
-        ("+7 499 1231212", "+7 499 123-12-12"),  # Moscow (Russia)
+        # ("+7 499 1231212", "+7 499 123-12-12"),  # Moscow (Russia)
         ("1-202-555-0104", "(202) 555-0104"),  # Washington DC (USA)
-        ("+23051234567", "+230 5123 4567"),  # Mauritius
-        ("+33(0)1 12345678", "+33 1 12 34 56 78"),  # Paris (France)
+        # ("+23051234567", "+230 5123 4567"),  # Mauritius
+        # ("+33(0)1 12345678", "+33 1 12 34 56 78"),  # Paris (France)
     ],
 )
 def test_format_us_and_international_phone_numbers(phone_number, expected_formatted):
@@ -408,7 +412,7 @@ def test_format_us_and_international_phone_numbers(phone_number, expected_format
         (None, ""),
         ("foo", "foo"),
         ("TeSt@ExAmPl3.com", "test@exampl3.com"),
-        ("+4407900 900 123", "+447900900123"),
+        # ("+4407900 900 123", "+447900900123"),
         ("+1 800 555 5555", "+18005555555"),
     ],
 )

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -519,9 +519,7 @@ def test_markdown_in_templates(
 def test_makes_links_out_of_URLs(
     extra_attributes, template_class, template_type, url, url_with_entities_replaced
 ):
-    assert (
-        '<a {} href="{}">{}</a>'
-    ).format(
+    assert ('<a {} href="{}">{}</a>').format(
         extra_attributes, url, url_with_entities_replaced
     ) in str(
         template_class({"content": url, "subject": "", "template_type": template_type})


### PR DESCRIPTION
The first check will be the country code.  If the country code is not 1, an error "Invalid country code" will be returned.  After that all other checks (not enough digits, too many digits, etc.) will be applied.

I've commented out all the international tests instead of removing them in case we change our minds about this decision.

Tested on my local.  I tried to send a text with +1<my phone number> and it went through fine.  Then I tried with +2<my phone number> and got "Invalid country code"