### PR TITLE
Links added to message templates are transposed into "Join Service" text #641

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -135,7 +135,7 @@ def create_sanitised_html_for_url(link, *, classes="", style=""):
     input: `http://foo.com/"bar"?x=1#2`
     output: `<a style=... href="http://foo.com/%22bar%22?x=1#2">http://foo.com/"bar"?x=1#2</a>`
     """
-    link_text = "Join Service"
+    link_text = "testing"
 
     if not link.lower().startswith("http"):
         link = f"http://{link}"

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -135,7 +135,7 @@ def create_sanitised_html_for_url(link, *, classes="", style=""):
     input: `http://foo.com/"bar"?x=1#2`
     output: `<a style=... href="http://foo.com/%22bar%22?x=1#2">http://foo.com/"bar"?x=1#2</a>`
     """
-    link_text = "testing"
+    link_text = link
 
     if not link.lower().startswith("http"):
         link = f"http://{link}"

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -187,7 +187,7 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
             content,
         )
 
-    def autolink(self, link, is_email=False):
+    def autolink(self, link, is_email=False): #
         if is_email:
             return link
         return create_sanitised_html_for_url(link, style=LINK_STYLE)

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -187,7 +187,7 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
             content,
         )
 
-    def autolink(self, link, is_email):
+    def autolink(self, link, is_email=False):
         if is_email:
             return link
         return create_sanitised_html_for_url(link, style=LINK_STYLE)

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -189,7 +189,7 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
 
     def autolink(self, link, is_email):
         if is_email:
-            return "this is linked"
+            return link
         return create_sanitised_html_for_url(link, style=LINK_STYLE)
 
 

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -187,7 +187,7 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
             content,
         )
 
-    def autolink(self, link, is_email=False): #
+    def autolink(self, link, is_email=False):
         if is_email:
             return link
         return create_sanitised_html_for_url(link, style=LINK_STYLE)

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -187,9 +187,9 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
             content,
         )
 
-    def autolink(self, link, is_email=False):
+    def autolink(self, link, is_email):
         if is_email:
-            return link
+            return "this is linked"
         return create_sanitised_html_for_url(link, style=LINK_STYLE)
 
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -29,11 +29,11 @@ from notifications_utils.template import (
     [
         (
             """https://example.com/"onclick="alert('hi')""",
-            """<a class="govuk-link govuk-link--no-visited-state" href="https://example.com/%22onclick=%22alert%28%27hi%27%29">Join Service</a>""",  # noqa
+            """<a class="govuk-link govuk-link--no-visited-state" href="https://example.com/%22onclick=%22alert%28%27hi%27%29">https://example.com/"onclick="alert('hi')</a>""",  # noqa
         ),
         (
             """https://example.com/"style='text-decoration:blink'""",
-            """<a class="govuk-link govuk-link--no-visited-state" href="https://example.com/%22style=%27text-decoration:blink%27">Join Service</a>""",  # noqa
+            """<a class="govuk-link govuk-link--no-visited-state" href="https://example.com/%22style=%27text-decoration:blink%27">https://example.com/"style='text-decoration:blink'</a>""",  # noqa
         ),
     ],
 )
@@ -46,7 +46,7 @@ def test_URLs_get_escaped_in_sms(url, expected_html):
 def test_HTML_template_has_URLs_replaced_with_links():
     assert (
         '<a style="word-wrap: break-word; color: #1D70B8;" href="https://service.example.com/accept_invite/a1b2c3d4">'
-        "Join Service"
+        "https://service.example.com/accept_invite/a1b2c3d4"
         "</a>"
     ) in str(
         HTMLEmailTemplate(
@@ -288,10 +288,10 @@ def test_removing_whitespace_before_full_stops(dirty, clean):
         ),
         (
             """
-            <a href="http://example.com?q='foo'">Join Service</a>
+            <a href="http://example.com?q='foo'">http://example.com?q='foo'</a>
         """,
             """
-            <a href="http://example.com?q='foo'">Join Service</a>
+            <a href="http://example.com?q='foo'">http://example.com?q='foo'</a>
         """,
         ),
     ],
@@ -440,93 +440,93 @@ def test_normalise_whitespace(value):
     (
         (
             "http://example.com",
-            '<a href="http://example.com">Join Service</a>',
+            '<a href="http://example.com">http://example.com</a>',
         ),
         (
             "https://example.com",
-            '<a href="https://example.com">Join Service</a>',
+            '<a href="https://example.com">https://example.com</a>',
         ),
         (
             "example.com",
-            '<a href="http://example.com">Join Service</a>',
+            '<a href="http://example.com">example.com</a>',
         ),
         (
             "www.foo.bar.example.com",
-            '<a href="http://www.foo.bar.example.com">Join Service</a>',
+            '<a href="http://www.foo.bar.example.com">www.foo.bar.example.com</a>',
         ),
         (
             "example.com/",
-            '<a href="http://example.com/">Join Service</a>',
+            '<a href="http://example.com/">example.com/</a>',
         ),
         (
             "www.foo.bar.example.com/",
-            '<a href="http://www.foo.bar.example.com/">Join Service</a>',
+            '<a href="http://www.foo.bar.example.com/">www.foo.bar.example.com/</a>',
         ),
         (
             "example.com/foo",
-            '<a href="http://example.com/foo">Join Service</a>',
+            '<a href="http://example.com/foo">example.com/foo</a>',
         ),
         (
             "example.com?foo",
-            '<a href="http://example.com?foo">Join Service</a>',
+            '<a href="http://example.com?foo">example.com?foo</a>',
         ),
         (
             "example.com#foo",
-            '<a href="http://example.com#foo">Join Service</a>',
+            '<a href="http://example.com#foo">example.com#foo</a>',
         ),
         (
             "Go to gov.uk/example.",
-            "Go to " '<a href="http://gov.uk/example">Join Service</a>.',
+            "Go to " '<a href="http://gov.uk/example">gov.uk/example</a>.',
         ),
         (
             "Go to gov.uk/example:",
-            "Go to " '<a href="http://gov.uk/example">Join Service</a>:',
+            "Go to " '<a href="http://gov.uk/example">gov.uk/example</a>:',
         ),
         (
             "Go to gov.uk/example;",
-            "Go to " '<a href="http://gov.uk/example;">Join Service</a>',
+            "Go to " '<a href="http://gov.uk/example;">gov.uk/example;</a>',
         ),
         (
             "(gov.uk/example)",
-            "(" '<a href="http://gov.uk/example">Join Service</a>)',
+            "(" '<a href="http://gov.uk/example">gov.uk/example</a>)',
         ),
         (
             "(gov.uk/example)...",
-            "(" '<a href="http://gov.uk/example">Join Service</a>)...',
+            "(" '<a href="http://gov.uk/example">gov.uk/example</a>)...',
         ),
         (
             "(gov.uk/example.)",
-            "(" '<a href="http://gov.uk/example">Join Service</a>.)',
+            "(" '<a href="http://gov.uk/example">gov.uk/example</a>.)',
         ),
         (
             "(see example.com/foo_(bar))",
-            "(see " '<a href="http://example.com/foo_%28bar%29">Join Service</a>)',
+            "(see " '<a href="http://example.com/foo_%28bar%29">example.com/foo_(bar)</a>)',
         ),
         (
             "example.com/foo(((((((bar",
-            '<a href="http://example.com/foo%28%28%28%28%28%28%28bar">Join Service</a>',
+            '<a href="http://example.com/foo%28%28%28%28%28%28%28bar">example.com/foo(((((((bar</a>',
         ),
         (
             "government website (gov.uk). Other websites…",
             "government website ("
-            '<a href="http://gov.uk">Join Service</a>). Other websites…',
+            '<a href="http://gov.uk">gov.uk</a>). Other websites…',
         ),
         (
             "[gov.uk/example]",
-            "[" '<a href="http://gov.uk/example">Join Service</a>]',
+            "[" '<a href="http://gov.uk/example">gov.uk/example</a>]',
         ),
         (
             "gov.uk/foo, gov.uk/bar",
-            '<a href="http://gov.uk/foo">Join Service</a>, '
-            '<a href="http://gov.uk/bar">Join Service</a>',
+            '<a href="http://gov.uk/foo">gov.uk/foo</a>, '
+            '<a href="http://gov.uk/bar">gov.uk/bar</a>',
         ),
         (
             "<p>gov.uk/foo</p>",
-            "<p>" '<a href="http://gov.uk/foo">Join Service</a></p>',
+            "<p>" '<a href="http://gov.uk/foo">gov.uk/foo</a></p>',
         ),
         (
             "gov.uk?foo&amp;",
-            '<a href="http://gov.uk?foo&amp;">Join Service</a>',
+            '<a href="http://gov.uk?foo&amp;">gov.uk?foo&amp;</a>',
         ),
         (
             "a .service.gov.uk domain",
@@ -534,7 +534,7 @@ def test_normalise_whitespace(value):
         ),
         (
             'http://foo.com/"bar"?x=1#2',
-            '<a href="http://foo.com/%22bar%22?x=1#2">Join Service</a>',
+            '<a href="http://foo.com/%22bar%22?x=1#2">http://foo.com/"bar"?x=1#2</a>',
         ),
         (
             "firstname.lastname@example.com",
@@ -555,13 +555,13 @@ def test_autolink_urls_matches_correctly(content, expected_html):
     (
         (
             {},
-            '<a href="http://example.com">Join Service</a>',
+            '<a href="http://example.com">http://example.com</a>',
         ),
         (
             {
                 "classes": "govuk-link",
             },
-            '<a class="govuk-link" href="http://example.com">Join Service</a>',
+            '<a class="govuk-link" href="http://example.com">http://example.com</a>',
         ),
     ),
 )

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -22,7 +22,6 @@ from notifications_utils.template import HTMLEmailTemplate
     ],
 )
 def test_makes_links_out_of_URLs(url):
-    link_text = "Join Service"
     link = (
         '<a style="word-wrap: break-word; color: #1D70B8;" href="{}">{}</a>'
     ).format(url, link_text)
@@ -40,7 +39,7 @@ def test_makes_links_out_of_URLs(url):
             ("this is some text with a link http://example.com in the middle"),
             (
                 "this is some text with a link "
-                '<a style="word-wrap: break-word; color: #1D70B8;" href="http://example.com">Join Service</a>'
+                '<a style="word-wrap: break-word; color: #1D70B8;" href="http://example.com">http://example.com</a>'
                 " in the middle"
             ),
         ),
@@ -48,9 +47,7 @@ def test_makes_links_out_of_URLs(url):
             ("this link is in brackets (http://example.com)"),
             (
                 "this link is in brackets "
-                "("
-                '<a style="word-wrap: break-word; color: #1D70B8;" href="http://example.com">'
-                "Join Service</a>)"
+                '(<a style="word-wrap: break-word; color: #1D70B8;" href="http://example.com">http://example.com</a>)'
             ),
         ),
     ],
@@ -88,7 +85,7 @@ def test_handles_placeholders_in_urls():
     ) == (
         '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
         '<a style="word-wrap: break-word; color: #1D70B8;" href="http://example.com/?token=">'
-        "Join Service"
+        "http://example.com/?token="
         "</a>"
         "<span class='placeholder'>((token))</span>&amp;key=1"
         "</p>"
@@ -100,13 +97,13 @@ def test_handles_placeholders_in_urls():
     [
         (
             """https://example.com"onclick="alert('hi')""",
-            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22onclick=%22alert%28%27hi">Join Service</a>')""",  # noqa
-            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22onclick=%22alert%28%27hi">Join Service</a>‘)""",  # noqa
+            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22onclick=%22alert%28%27hi">https://example.com"onclick="alert('hi</a>')""",  # noqa
+            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22onclick=%22alert%28%27hi">https://example.com"onclick="alert('hi</a>‘)""",  # noqa
         ),
         (
             """https://example.com"style='text-decoration:blink'""",
-            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22style=%27text-decoration:blink">Join Service</a>'""",  # noqa
-            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22style=%27text-decoration:blink">Join Service</a>’""",  # noqa
+            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22style=%27text-decoration:blink">https://example.com"style='text-decoration:blink</a>'""",  # noqa
+            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22style=%27text-decoration:blink">https://example.com"style='text-decoration:blink</a>’""",  # noqa
         ),
     ],
 )
@@ -135,7 +132,7 @@ def test_URLs_get_escaped(url, expected_html, expected_html_in_template):
             (
                 '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
                 '<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com">'
-                "Join Service"
+                "https://example.com"
                 "</a>"
                 "</p>"
                 '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
@@ -463,8 +460,7 @@ def test_table(markdown_function):
             "http://example.com",
             (
                 '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
-                '<a style="word-wrap: break-word; color: #1D70B8;" href="http://example.com">'
-                "Join Service</a>"
+                '<a style="word-wrap: break-word; color: #1D70B8;" href="http://example.com">http://example.com</a>'
                 "</p>"
             ),
         ],
@@ -475,7 +471,7 @@ def test_table(markdown_function):
                 '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
                 '<a style="word-wrap: break-word; color: #1D70B8;" '
                 'href="https://example.com%22onclick=%22alert%28%27hi">'
-                "Join Service"
+                'https://example.com"onclick="alert(\'hi'
                 "</a>')"
                 "</p>"
             ),

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -22,9 +22,9 @@ from notifications_utils.template import HTMLEmailTemplate
     ],
 )
 def test_makes_links_out_of_URLs(url):
-    link = (
-        '<a style="word-wrap: break-word; color: #1D70B8;" href="{}">{}</a>'
-    ).format(url, link_text)
+    link = '<a style="word-wrap: break-word; color: #1D70B8;" href="{}">{}</a>'.format(
+        url, url
+    )
     assert notify_email_markdown(url) == (
         '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
         "{}"

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -519,8 +519,8 @@ def test_markdown_in_templates(
 def test_makes_links_out_of_URLs(
     extra_attributes, template_class, template_type, url, url_with_entities_replaced
 ):
-    assert ('<a {} href="{}">{}</a>').format(
-        extra_attributes, url, url_with_entities_replaced
+    assert '<a {} href="{}">{}</a>'.format(
+        extra_attributes, url_with_entities_replaced, url_with_entities_replaced
     ) in str(
         template_class({"content": url, "subject": "", "template_type": template_type})
     )

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -493,25 +493,25 @@ def test_markdown_in_templates(
 @pytest.mark.parametrize(
     "url, url_with_entities_replaced",
     [
-        ("http://example.com", "Join Service"),
-        ("http://www.gov.uk/", "Join Service"),
-        ("https://www.gov.uk/", "Join Service"),
-        ("http://service.gov.uk", "Join Service"),
+        ("http://example.com", "http://example.com"),
+        ("http://www.gov.uk/", "http://www.gov.uk/"),
+        ("https://www.gov.uk/", "https://www.gov.uk/"),
+        ("http://service.gov.uk", "http://service.gov.uk"),
         (
+            "http://service.gov.uk/blah.ext?q=a%20b%20c&order=desc#fragment",
             "http://service.gov.uk/blah.ext?q=a%20b%20c&amp;order=desc#fragment",
-            "Join Service",
         ),
-        pytest.param("example.com", "Join Service", marks=pytest.mark.xfail),
-        pytest.param("www.example.com", "Join Service", marks=pytest.mark.xfail),
+        pytest.param("example.com", "example.com", marks=pytest.mark.xfail),
+        pytest.param("www.example.com", "www.example.com", marks=pytest.mark.xfail),
         pytest.param(
             "http://service.gov.uk/blah.ext?q=one two three",
-            "Join Service",
+            "http://service.gov.uk/blah.ext?q=one two three",
             marks=pytest.mark.xfail,
         ),
-        pytest.param("ftp://example.com", "Join Service", marks=pytest.mark.xfail),
+        pytest.param("ftp://example.com", "ftp://example.com", marks=pytest.mark.xfail),
         pytest.param(
             "mailto:test@example.com",
-            "Join Service",
+            "mailto:test@example.com",
             marks=pytest.mark.xfail,
         ),
     ],
@@ -536,13 +536,13 @@ def test_makes_links_out_of_URLs(
 @pytest.mark.parametrize(
     "url, url_with_entities_replaced",
     (
-        ("example.com", "Join Service"),
-        ("www.gov.uk/", "Join Service"),
-        ("service.gov.uk", "Join Service"),
-        ("gov.uk/coronavirus", "Join Service"),
+        ("example.com", "example.com"),
+        ("www.gov.uk/", "www.gov.uk/"),
+        ("service.gov.uk", "service.gov.uk"),
+        ("gov.uk/coronavirus", "gov.uk/coronavirus"),
         (
+            "service.gov.uk/blah.ext?q=a%20b%20c&order=desc#fragment",
             "service.gov.uk/blah.ext?q=a%20b%20c&amp;order=desc#fragment",
-            "Join Service",
         ),
     ),
 )
@@ -555,7 +555,7 @@ def test_makes_links_out_of_URLs_without_protocol_in_sms_and_broadcast(
     assert (
         f"<a "
         f'class="govuk-link govuk-link--no-visited-state" '
-        f'href="http://{url}">'
+        f'href="http://{url_with_entities_replaced}">'
         f"{url_with_entities_replaced}"
         f"</a>"
     ) in str(
@@ -576,7 +576,7 @@ def test_makes_links_out_of_URLs_without_protocol_in_sms_and_broadcast(
             (
                 '<a style="word-wrap: break-word; color: #1D70B8;"'
                 ' href="https://service.example.com/accept_invite/a1b2c3d4">'
-                "Join Service"
+                "https://service.example.com/accept_invite/a1b2c3d4"
                 "</a>"
             ),
         ),
@@ -585,7 +585,7 @@ def test_makes_links_out_of_URLs_without_protocol_in_sms_and_broadcast(
             (
                 '<a style="word-wrap: break-word; color: #1D70B8;"'
                 ' href="https://service.example.com/accept_invite/?a=b&amp;c=d&amp;">'
-                "Join Service"
+                "https://service.example.com/accept_invite/?a=b&amp;c=d&amp;"
                 "</a>"
             ),
         ),


### PR DESCRIPTION
![image](https://github.com/GSA/notifications-utils/assets/53159604/64369439-ace9-449e-a8e2-58695b3a801e)

ticket related: https://github.com/GSA/notifications-api/issues/641