### PR TITLE
Bump utils to 0.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "0.2.3"
+version = "0.2.4"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"


### PR DESCRIPTION
This changeset bumps the utils release version to 0.2.4 in prep for our next production release.

## Security Considerations

- None with this change.