### PR TITLE
#1125 bug sms fragment

### DIFF
--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -272,6 +272,8 @@ class BaseSMSTemplate(Template):
         then fragments based on multipart message rules. ASCII
         was not specifically called out as almost all messages will
         switch from 7bit GSM to Unicode.
+        
+        Calculations are based on https://messente.com/documentation/tools/sms-length-calculator
         """
         if gsm_check(message_str):
             if content_len <= 160:

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -255,7 +255,7 @@ class BaseSMSTemplate(Template):
         and that counting bytes should suffice.
         """
 
-        #check if all chars are in the GSM-7 character set
+        # check if all chars are in the GSM-7 character set
         def gsm_check(x):
             rule = re.compile(r'^[\sa-zA-Z0-9_@?£!1$"¥#è?¤é%ù&ì\\ò(Ç)*:Ø+;ÄäøÆ,<LÖlöæ\-=ÑñÅß.>ÜüåÉ/§à¡¿\']+$')
             if not rule.search(x):
@@ -268,7 +268,7 @@ class BaseSMSTemplate(Template):
         content_len = len(message_str)
 
         """
-        Checks for GSM-7 char set, calculates msg size, and 
+        Checks for GSM-7 char set, calculates msg size, and
         then fragments based on multipart message rules. ASCII
         was not specifically called out as almost all messages will
         switch from 7bit GSM to Unicode.
@@ -276,10 +276,10 @@ class BaseSMSTemplate(Template):
         if gsm_check(message_str):
             if content_len <= 160:
                 return math.ceil(content_len / 160)
-            else: 
+            else:
                 return math.ceil(content_len / 153)
         else:
-            if content_len <= 70: 
+            if content_len <= 70:
                 return math.ceil(content_len / 70)
             else:
                 return math.ceil(content_len / 67)

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -257,7 +257,9 @@ class BaseSMSTemplate(Template):
 
         # check if all chars are in the GSM-7 character set
         def gsm_check(x):
-            rule = re.compile(r'^[\sa-zA-Z0-9_@?£!1$"¥#è?¤é%ù&ì\\ò(Ç)*:Ø+;ÄäøÆ,<LÖlöæ\-=ÑñÅß.>ÜüåÉ/§à¡¿\']+$')
+            rule = re.compile(
+                r'^[\sa-zA-Z0-9_@?£!1$"¥#è?¤é%ù&ì\\ò(Ç)*:Ø+;ÄäøÆ,<LÖlöæ\-=ÑñÅß.>ÜüåÉ/§à¡¿\']+$'
+            )
             gsm_match = rule.search(x)
             if gsm_match is None:
                 return False
@@ -272,7 +274,7 @@ class BaseSMSTemplate(Template):
         then fragments based on multipart message rules. ASCII
         was not specifically called out as almost all messages will
         switch from 7bit GSM to Unicode.
-        
+
         Calculations are based on https://messente.com/documentation/tools/sms-length-calculator
         """
         if gsm_check(message_str):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -271,7 +271,8 @@ class BaseSMSTemplate(Template):
         Checks for GSM-7 char set, calculates msg size, and
         then fragments based on multipart message rules. ASCII
         was not specifically called out as almost all messages will
-        switch from 7bit GSM to Unicode.        
+        switch from 7bit GSM to Unicode.
+        
         Calculations are based on https://messente.com/documentation/tools/sms-length-calculator
         """
         if gsm_check(message_str):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -1,4 +1,5 @@
 import math
+import re
 from abc import ABC, abstractmethod
 from datetime import datetime
 from functools import lru_cache
@@ -253,8 +254,33 @@ class BaseSMSTemplate(Template):
         Since we are supporting more or less "all" languages, it doesn't seem like we really want to count chars,
         and that counting bytes should suffice.
         """
-        content_len = len(self.content_with_placeholders_filled_in.encode("utf8"))
-        return math.ceil(content_len / 140)
+        #check if all chars are in the GSM-7 character set
+        def gsm_check(x):
+            rule = re.compile(r'^[\sa-zA-Z0-9_@?£!1$"¥#è?¤é%ù&ì\\ò(Ç)*:Ø+;ÄäøÆ,<LÖlöæ\-=ÑñÅß.>ÜüåÉ/§à¡¿\']+$')
+            if not rule.search(x):
+                return False
+            else:
+                return True
+
+        message_str = self.content_with_placeholders_filled_in
+
+        content_len = len(message_str)
+        """
+        Checks for GSM-7 char set, calculates msg size, and 
+        then fragments based on multipart message rules. ASCII
+        was not specifically called out as almost all messages will
+        switch from 7bit GSM to Unicode.
+        """
+        if gsm_check(message_str):
+            if content_len <= 160:
+                return math.ceil(content_len / 160)
+            else: 
+                return math.ceil(content_len / 153)
+        else:
+            if content_len <= 70: 
+                return math.ceil(content_len / 70)
+            else:
+                return math.ceil(content_len / 67)
 
     def is_message_too_long(self):
         """

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -271,8 +271,7 @@ class BaseSMSTemplate(Template):
         Checks for GSM-7 char set, calculates msg size, and
         then fragments based on multipart message rules. ASCII
         was not specifically called out as almost all messages will
-        switch from 7bit GSM to Unicode.
-        
+        switch from 7bit GSM to Unicode.        
         Calculations are based on https://messente.com/documentation/tools/sms-length-calculator
         """
         if gsm_check(message_str):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -254,6 +254,7 @@ class BaseSMSTemplate(Template):
         Since we are supporting more or less "all" languages, it doesn't seem like we really want to count chars,
         and that counting bytes should suffice.
         """
+
         #check if all chars are in the GSM-7 character set
         def gsm_check(x):
             rule = re.compile(r'^[\sa-zA-Z0-9_@?£!1$"¥#è?¤é%ù&ì\\ò(Ç)*:Ø+;ÄäøÆ,<LÖlöæ\-=ÑñÅß.>ÜüåÉ/§à¡¿\']+$')
@@ -265,6 +266,7 @@ class BaseSMSTemplate(Template):
         message_str = self.content_with_placeholders_filled_in
 
         content_len = len(message_str)
+
         """
         Checks for GSM-7 char set, calculates msg size, and 
         then fragments based on multipart message rules. ASCII

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -272,7 +272,6 @@ class BaseSMSTemplate(Template):
         then fragments based on multipart message rules. ASCII
         was not specifically called out as almost all messages will
         switch from 7bit GSM to Unicode.
-        
         Calculations are based on https://messente.com/documentation/tools/sms-length-calculator
         """
         if gsm_check(message_str):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -258,10 +258,10 @@ class BaseSMSTemplate(Template):
         # check if all chars are in the GSM-7 character set
         def gsm_check(x):
             rule = re.compile(r'^[\sa-zA-Z0-9_@?£!1$"¥#è?¤é%ù&ì\\ò(Ç)*:Ø+;ÄäøÆ,<LÖlöæ\-=ÑñÅß.>ÜüåÉ/§à¡¿\']+$')
-            if not rule.search(x):
+            gsm_match = rule.search(x)
+            if gsm_match is None:
                 return False
-            else:
-                return True
+            return True
 
         message_str = self.content_with_placeholders_filled_in
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -272,6 +272,7 @@ class BaseSMSTemplate(Template):
         then fragments based on multipart message rules. ASCII
         was not specifically called out as almost all messages will
         switch from 7bit GSM to Unicode.
+        
         Calculations are based on https://messente.com/documentation/tools/sms-length-calculator
         """
         if gsm_check(message_str):

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1598,8 +1598,9 @@ def test_sms_fragment_count_accounts_for_unicode_and_welsh_characters(
         ("Hello Carlos. Your Example Corp. bill of $100 is now available. Autopay is scheduled for next Thursday,\
          April 9. To view the details of your bill, go to https://example.com/bill1.", 2),
         ("亚马逊公司是一家总部位于美国西雅图的跨国电子商务企业，业务起始于线上书店，不久之后商品走向多元化。杰夫·贝佐斯于1994年7月创建了这家公司。", 2),
-        #This test should break into two messages, but \u2019 gets converted to (')
-        ("John: Your appointment with Dr. Salazar’s office is scheduled for next Thursday at 4:30pm. Reply YES to confirm, NO to reschedule.", 1),
+        # This test should break into two messages, but \u2019 gets converted to (')
+        ("John: Your appointment with Dr. Salazar’s office is scheduled for next Thursday at 4:30pm.\
+          Reply YES to confirm, NO to reschedule.", 1),
     ],
 )
 def test_sms_fragment_count_accounts_for_non_latin_characters(

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1553,7 +1553,7 @@ def test_character_count_for_broadcast_templates(
     [
         (
             "This is a very long long long long long long long long long long long long long long long long long long long long long long long long text message.",  # noqa
-            2,
+            1,
         ),
         ("This is a short message.", 1),
     ],

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1592,15 +1592,27 @@ def test_sms_fragment_count_accounts_for_unicode_and_welsh_characters(
         ("これは、システムがコストをどのように計算するかをテストするためのロシア語の長いメッセージです", 1),
         ("这是一条很长的俄语消息，用于测试系统如何计算其成本", 1),
         ("这是一个非常长的长长长长的长长长长的长长长长的长长长长的长长长长长长长长长长长长的长长长长的长篇短信", 1),
-        ("これは、システムがコストをどのように計算するかをテストするためのロシア語の長いメッセージです foo foofoofoofoofoofoofoofoo", 2),
-        ("Это длинное сообщение на русском языке, чтобы проверить, как система рассчитывает его стоимость.\
-          foo foo foo foo foo foo foo foo foo foo", 3),
-        ("Hello Carlos. Your Example Corp. bill of $100 is now available. Autopay is scheduled for next Thursday,\
-         April 9. To view the details of your bill, go to https://example.com/bill1.", 2),
+        (
+            "これは、システムがコストをどのように計算するかをテストするためのロシア語の長いメッセージです foo foofoofoofoofoofoofoofoo",
+            2,
+        ),
+        (
+            "Это длинное сообщение на русском языке, чтобы проверить, как система рассчитывает его стоимость.\
+          foo foo foo foo foo foo foo foo foo foo",
+            3,
+        ),
+        (
+            "Hello Carlos. Your Example Corp. bill of $100 is now available. Autopay is scheduled for next Thursday,\
+         April 9. To view the details of your bill, go to https://example.com/bill1.",
+            2,
+        ),
         ("亚马逊公司是一家总部位于美国西雅图的跨国电子商务企业，业务起始于线上书店，不久之后商品走向多元化。杰夫·贝佐斯于1994年7月创建了这家公司。", 2),
         # This test should break into two messages, but \u2019 gets converted to (')
-        ("John: Your appointment with Dr. Salazar’s office is scheduled for next Thursday at 4:30pm.\
-          Reply YES to confirm, NO to reschedule.", 1),
+        (
+            "John: Your appointment with Dr. Salazar’s office is scheduled for next Thursday at 4:30pm.\
+          Reply YES to confirm, NO to reschedule.",
+            1,
+        ),
     ],
 )
 def test_sms_fragment_count_accounts_for_non_latin_characters(

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1588,14 +1588,18 @@ def test_sms_fragment_count_accounts_for_unicode_and_welsh_characters(
             "이것은 매우 길고 오래 오래 오래 오래 오래 오래 오래 오래 오래 오래 오래 오래 오래 오래 오래 오래 오래 오래 오래 오래 긴 문자 메시지입니다.",
             2,
         ),
-        ("Αυτό είναι ένα μεγάλο μήνυμα στα ρωσικά για να ελέγξετε πώς το για αυτό", 1),
+        ("Αυτό είναι ένα μεγάλο μήνυμα στα ρωσικά για να ελέγξετε πώς το για αυτό", 2),
         ("これは、システムがコストをどのように計算するかをテストするためのロシア語の長いメッセージです", 1),
         ("这是一条很长的俄语消息，用于测试系统如何计算其成本", 1),
-        ("这是一个非常长的长长长长的长长长长的长长长长的长长长长的长长长长长长长长长长长长的长长长长的长篇短信", 2),
+        ("这是一个非常长的长长长长的长长长长的长长长长的长长长长的长长长长长长长长长长长长的长长长长的长篇短信", 1),
         ("これは、システムがコストをどのように計算するかをテストするためのロシア語の長いメッセージです foo foofoofoofoofoofoofoofoo", 2),
         ("Это длинное сообщение на русском языке, чтобы проверить, как система рассчитывает его стоимость.\
-          foo foo foo foo foo foo foo foo foo foo", 2),
-        ("这是一条很长的俄语消息，foo foo foo foo foo foo foo foo foo foo foo foo 用于测试系统如何计算其成本", 1)
+          foo foo foo foo foo foo foo foo foo foo", 3),
+        ("Hello Carlos. Your Example Corp. bill of $100 is now available. Autopay is scheduled for next Thursday,\
+         April 9. To view the details of your bill, go to https://example.com/bill1.", 2),
+        ("亚马逊公司是一家总部位于美国西雅图的跨国电子商务企业，业务起始于线上书店，不久之后商品走向多元化。杰夫·贝佐斯于1994年7月创建了这家公司。", 2),
+        #This test should break into two messages, but \u2019 gets converted to (')
+        ("John: Your appointment with Dr. Salazar’s office is scheduled for next Thursday at 4:30pm. Reply YES to confirm, NO to reschedule.", 1),
     ],
 )
 def test_sms_fragment_count_accounts_for_non_latin_characters(


### PR DESCRIPTION
Corrected message formatting bugs in the template.py to match AWS formatting rules and updated test cases. All test case fragments were validated with https://messente.com/documentation/tools/sms-length-calculator