### PR TITLE
Update utils to 0.2.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "0.2.7"
+version = "0.2.8"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="notifications-utils",
-    version="0.2.7",
+    version="0.2.8",
     url="https://github.com/GSA/notifications-utils",
     license_files=("LICENSE.md",),
     author="General Services Administration",


### PR DESCRIPTION
This changeset bumps the notifications-utils release to 0.2.8 to account for a cryptography dependency update that addresses a Dependabot security alert.

## Security Considerations

- Allows us to update the API and Admin projects to account for the cryptography update and keep our project dependencies up-to-date.