### PR TITLE
remove noqas (notify-utils-74)

### DIFF
--- a/notifications_utils/celery.py
+++ b/notifications_utils/celery.py
@@ -29,7 +29,7 @@ def make_task(app):
                 g.request_id = self.request_id
                 yield
 
-        def on_success(self, retval, task_id, args, kwargs):  # noqa
+        def on_success(self, retval, task_id, args, kwargs):
             # enables request id tracing for these logs
             with self.app_context():
                 elapsed_time = time.monotonic() - self.start
@@ -42,7 +42,7 @@ def make_task(app):
                     )
                 )
 
-        def on_failure(self, exc, task_id, args, kwargs, einfo):  # noqa
+        def on_failure(self, exc, task_id, args, kwargs, einfo):
             # enables request id tracing for these logs
             with self.app_context():
                 app.logger.exception(

--- a/notifications_utils/celery.py
+++ b/notifications_utils/celery.py
@@ -33,7 +33,8 @@ def make_task(app):
             # enables request id tracing for these logs
             with self.app_context():
                 elapsed_time = time.monotonic() - self.start
-
+                # To avoid deadcode warning
+                app.logger.debug(f"Celery task retval {retval} task_id {task_id}")
                 app.logger.info(
                     "Celery task {task_name} (queue: {queue_name}) took {time}".format(
                         task_name=self.name,
@@ -45,6 +46,8 @@ def make_task(app):
         def on_failure(self, exc, task_id, args, kwargs, einfo):
             # enables request id tracing for these logs
             with self.app_context():
+                # To avoid deadcode warning
+                app.logger.debug(f"Celery task einfo {einfo}")
                 app.logger.exception(
                     "Celery task {task_name} (queue: {queue_name}) failed".format(
                         task_name=self.name,

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -58,13 +58,13 @@ mistune.InlineLexer.inline_html_rules = list(
 
 
 class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
-    def block_code(self, code, language=None):  # noqa
+    def block_code(self, code, language=None):
         return code
 
     def block_quote(self, text):
         return text
 
-    def header(self, text, level, raw=None):  # noqa
+    def header(self, text, level, raw=None):
         if level == 1:
             return super().header(text, 2)
         return self.paragraph(text)
@@ -85,7 +85,7 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
             link.replace("http://", "").replace("https://", "")
         )
 
-    def image(self, src, title, alt_text):  # noqa
+    def image(self, src, title, alt_text):
         return ""
 
     def linebreak(self):
@@ -111,7 +111,7 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
 
 
 class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
-    def header(self, text, level, raw=None):  # noqa
+    def header(self, text, level, raw=None):
         if level == 1:
             return (
                 '<h2 style="Margin: 0 0 20px 0; padding: 0; '
@@ -196,7 +196,7 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
 class NotifyPlainTextEmailMarkdownRenderer(NotifyEmailMarkdownRenderer):
     COLUMN_WIDTH = 65
 
-    def header(self, text, level, raw=None):  # noqa
+    def header(self, text, level, raw=None):
         if level == 1:
             return "".join(
                 (
@@ -268,7 +268,7 @@ class NotifyPlainTextEmailMarkdownRenderer(NotifyEmailMarkdownRenderer):
 
 
 class NotifyEmailPreheaderMarkdownRenderer(NotifyPlainTextEmailMarkdownRenderer):
-    def header(self, text, level, raw=None):  # noqa
+    def header(self, text, level, raw=None):
         return self.paragraph(text)
 
     def hrule(self):

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -58,13 +58,18 @@ mistune.InlineLexer.inline_html_rules = list(
 
 
 class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
-    def block_code(self, code, language=None):
+    # TODO if we start removing the dead code detected by
+    # the vulture tool (such as the parameter 'language' here)
+    # it will break all the tests.  Need to do some massive
+    # cleanup apparently, although it's not clear why vulture
+    # only recently started detecting this.
+    def block_code(self, code, language=None):  # noqa
         return code
 
     def block_quote(self, text):
         return text
 
-    def header(self, text, level, raw=None):
+    def header(self, text, level, raw=None):  # noqa
         if level == 1:
             return super().header(text, 2)
         return self.paragraph(text)
@@ -85,7 +90,7 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
             link.replace("http://", "").replace("https://", "")
         )
 
-    def image(self, src, title, alt_text):
+    def image(self, src, title, alt_text):  # noqa
         return ""
 
     def linebreak(self):
@@ -111,7 +116,7 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
 
 
 class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
-    def header(self, text, level, raw=None):
+    def header(self, text, level, raw=None):  # noqa
         if level == 1:
             return (
                 '<h2 style="Margin: 0 0 20px 0; padding: 0; '
@@ -196,7 +201,7 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
 class NotifyPlainTextEmailMarkdownRenderer(NotifyEmailMarkdownRenderer):
     COLUMN_WIDTH = 65
 
-    def header(self, text, level, raw=None):
+    def header(self, text, level, raw=None):  # noqa
         if level == 1:
             return "".join(
                 (
@@ -263,12 +268,12 @@ class NotifyPlainTextEmailMarkdownRenderer(NotifyEmailMarkdownRenderer):
             )
         )
 
-    def autolink(self, link, is_email=False):
+    def autolink(self, link, is_email=False):  # noqa
         return link
 
 
 class NotifyEmailPreheaderMarkdownRenderer(NotifyPlainTextEmailMarkdownRenderer):
-    def header(self, text, level, raw=None):
+    def header(self, text, level, raw=None):  # noqa
         return self.paragraph(text)
 
     def hrule(self):

--- a/tests/test_base64_uuid.py
+++ b/tests/test_base64_uuid.py
@@ -44,10 +44,10 @@ def test_base64_converter_to_url(python_val):
     ],
 )
 def test_base64_converter_to_python_raises_validation_error(url_val):
-    with pytest.raises(Exception):  # noqa B017
+    with pytest.raises(BaseException):
         base64_to_uuid(url_val)
 
 
 def test_base64_converter_to_url_raises_validation_error():
-    with pytest.raises(Exception):  # noqa B017
+    with pytest.raises(AttributeError):
         uuid_to_base64(object())

--- a/tests/test_letter_timings.py
+++ b/tests/test_letter_timings.py
@@ -13,7 +13,7 @@ from notifications_utils.letter_timings import (
 @freeze_time("2017-07-14 13:59:59")  # Friday, before print deadline (3PM EST)
 @pytest.mark.parametrize(
     "upload_time, expected_print_time, is_printed, first_class, expected_earliest, expected_latest",
-    [  # noqa
+    [
         # EST
         # ==================================================================
         #  First thing Monday
@@ -155,9 +155,10 @@ def test_get_estimated_delivery_date_for_letter(
 ):
     # remove the day string from the upload_time, which is purely informational
 
-    format_dt = lambda x: x.astimezone(  # noqa E731
-        pytz.timezone("America/New_York")
-    ).strftime("%A %Y-%m-%d %H:%M")
+    def format_dt(x):
+        return x.astimezone(pytz.timezone("America/New_York")).strftime(
+            "%A %Y-%m-%d %H:%M"
+        )
 
     upload_time = upload_time.split(" ", 1)[1]
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -14,8 +14,8 @@ def test_get_handlers_sets_up_logging_appropriately_with_debug():
     handlers = logging.get_handlers(app)
 
     assert len(handlers) == 1
-    assert type(handlers[0]) == builtin_logging.StreamHandler  # noqa E721
-    assert type(handlers[0].formatter) == builtin_logging.Formatter  # noqa E721
+    assert isinstance(handlers[0], builtin_logging.StreamHandler)
+    assert isinstance(handlers[0].formatter, builtin_logging.Formatter)
 
 
 def test_get_handlers_sets_up_logging_appropriately_without_debug():
@@ -28,8 +28,8 @@ def test_get_handlers_sets_up_logging_appropriately_without_debug():
     handlers = logging.get_handlers(app)
 
     assert len(handlers) == 1
-    assert type(handlers[0]) == builtin_logging.StreamHandler  # noqa E721
-    assert type(handlers[0].formatter) == logging.JSONFormatter  # noqa E721
+    assert isinstance(handlers[0], builtin_logging.StreamHandler)
+    assert isinstance(handlers[0].formatter, logging.JSONFormatter)
 
 
 def test_base_json_formatter_contains_service_id():

--- a/tests/test_request_header_authentication.py
+++ b/tests/test_request_header_authentication.py
@@ -1,5 +1,3 @@
-from unittest import mock  # noqa
-
 import pytest
 from werkzeug.test import EnvironBuilder
 

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -158,9 +158,10 @@ def test_sms_encoding_get_non_compatible_characters(content, cls, expected):
         ),  # Chinese from wikipedia 2
         ("哪一種多邊形內部至少存在一個可以看見多邊形所有邊界和所有內部區域的點？", True),  # Chinese from wikipedia 3
         (
-            "都柏林在官方城市邊界內的人口是大約495,000人（愛爾蘭中央統計處2002年人口調查），然而這種統計已經沒有什麼太大的意義，因為都柏林的市郊地區和衛星城鎮已經大幅地發展與擴張。",
+            """都柏林在官方城市邊界內的人口是大約495,000人（愛爾蘭中央統計處2002年人口調查），
+            然而這種統計已經沒有什麼太大的意義，因為都柏林的市郊地區和衛星城鎮已經大幅地發展與擴張。""",
             True,
-        ),  # noqa too long # Chinese from wikipedia 4
+        ),  # Chinese from wikipedia 4
         (
             "一名是Dubh Linn（愛爾蘭語，意為「黑色的水池」）的英國習語。當然也有人質疑這語源。",
             True,
@@ -183,15 +184,20 @@ def test_sms_encoding_get_non_compatible_characters(content, cls, expected):
             True,
         ),  # Chinese from wikipedia 10
         (
-            "Dưới đây là danh sách tất cả các tên người dùng hiện đang có tại Wikipedia, hoặc những tên người dùng trong một nhóm chỉ định. ",  # noqa too long
+            """Dưới đây là danh sách tất cả các tên người dùng hiện đang có
+            tại Wikipedia, hoặc những tên người dùng trong một nhóm chỉ định. """,
             True,
         ),  # Vietnamese from wikipedia 1
         (
-            "Các bảo quản viên đảm nhận những trách nhiệm này với tư cách là tình nguyện viên sau khi trải qua quá trình xem xét của cộng đồng. ",  # noqa too long
+            """Các bảo quản viên đảm nhận những trách nhiệm này với tư cách là tình
+            nguyện viên sau khi trải qua quá trình xem xét của cộng đồng. """,
             True,
         ),  # Vietnamese from wikipedia 2
         (
-            'Họ không bao giờ được yêu cầu sử dụng các công cụ của mình và không bao giờ được sử dụng chúng để giành lợi thế trong một cuộc tranh chấp mà họ có tham gia. Không nên nhầm lẫn bảo quản viên với quản trị viên hệ thống của Wikimedia ("sysadmins").',  # noqa too long
+            """Họ không bao giờ được yêu cầu sử dụng các công cụ của mình và không bao
+            giờ được sử dụng chúng để giành lợi thế trong một cuộc tranh chấp mà họ có
+            tham gia. Không nên nhầm lẫn bảo quản viên với quản trị viên hệ
+            thống của Wikimedia ("sysadmins").""",
             True,
         ),  # Vietnamese from wikipedia 3
         (
@@ -204,7 +210,8 @@ def test_sms_encoding_get_non_compatible_characters(content, cls, expected):
             True,
         ),  # Vietnamese from wikipedia 6
         (
-            "Bài viết ở Wikipedia có thể chứa đựng từ ngữ và hình ảnh gây khó chịu nhưng chỉ vì mục đích tốt đẹp. Không cần thêm vào phủ định trách nhiệm.",  # noqa too long
+            """Bài viết ở Wikipedia có thể chứa đựng từ ngữ và hình ảnh gây khó chịu
+            nhưng chỉ vì mục đích tốt đẹp. Không cần thêm vào phủ định trách nhiệm.""",
             True,
         ),  # Vietnamese from wikipedia 7
         (
@@ -212,11 +219,13 @@ def test_sms_encoding_get_non_compatible_characters(content, cls, expected):
             True,
         ),  # Vietnamese from wikipedia 8
         (
-            "Trích dẫn bất cứ nôi dung tranh luận gốc nào cũng nên có liên quan đến tranh luận đó (hoặc minh họa cho phong cách) và chỉ nên dài vừa đủ.",  # noqa too long
+            """Trích dẫn bất cứ nôi dung tranh luận gốc nào cũng nên có liên quan
+            đến tranh luận đó (hoặc minh họa cho phong cách) và chỉ nên dài vừa đủ.""",
             True,
         ),  # Vietnamese from wikipedia 9
         (
-            "Không tung tin vịt, thông tin sai lệch hoặc nội dung không kiểm chứng được vào bài viết. Tuy nhiên, những bài viết về những tin vịt nổi bật được chấp nhận.",  # noqa too long
+            """Không tung tin vịt, thông tin sai lệch hoặc nội dung không kiểm chứng được vào bài viết.
+            Tuy nhiên, những bài viết về những tin vịt nổi bật được chấp nhận.""",
             True,
         ),  # Vietnamese from wikipedia 10
         (
@@ -232,21 +241,29 @@ def test_sms_encoding_get_non_compatible_characters(content, cls, expected):
             True,
         ),  # State of Washington Chinese Simplified
         (
-            "DSHS៖ ប ើងោនកត់សម្គា ល់ប ើញក្ដរបោកប្រោស់ជាសក្ដា នុពលបៅបលើគណនីរបស់អ្នក។ សូមបៅបៅបលខ #បៅបលើខនងក្ដត EBT របស់អ្នក ប ើមបីបោោះបង់ ឬក៏បៅក្ដន់ក្ដរយាិ ល័ បៅកនុងតំបន់របស់អ្នក ប ើមបីបសនើសុំក្ដតថ្មី។ ប្លើ តបជាអ្កសរ ឈប់ ប ើមបីបញ្ឈប់",  # noqa too long
+            """DSHS៖ ប ើងោនកត់សម្គា ល់ប ើញក្ដរបោកប្រោស់ជាសក្ដា នុពលបៅបលើគណនីរបស់អ្នក។ សូមបៅបៅបលខ #បៅបលើខនងក្ដត
+            EBT របស់អ្នក ប ើមបីបោោះបង់ ឬក៏បៅក្ដន់ក្ដរយាិ ល័ បៅកនុងតំបន់របស់អ្នក
+            ប ើមបីបសនើសុំក្ដតថ្មី។ ប្លើ តបជាអ្កសរ ឈប់ ប ើមបីបញ្ឈប់""",
             True,
         ),  # State of Washington Khmer
         (
-            "DSHS: 귀하의 계정 상에 사기가 일어났을 가능성이 포착되었습니다. 귀하의 EBT 카드 뒷면에있는 번호로 전화를 걸어 취소하거나 현지 사무소로 가서 새 것을 발급 받으세요. 중단하려면중단이라고 회신하세요.",  # noqa too long
+            """DSHS: 귀하의 계정 상에 사기가 일어났을 가능성이 포착되었습니다. 귀하의 EBT 카드 뒷면에있는
+            번호로 전화를 걸어 취소하거나 현지 사무소로 가서 새 것을 발급 받으세요. 중단하려면중단이라고 회신하세요.""",
             True,
         ),  # State of WA Korean
         (
-            "ຂ ຄໍ້ ວາມການສໍ້ໂກງທອາດເປັນໄປໄດ ໍ້ DSHS: ພວກເຮາົໄດສໍ້ງັເກດເຫນັການສໂກງທີ່ອາດເປັນໄປໄດໃໍ້ນບນັຊຂ ອງທີ່ານ. ໂທຫາ # ທ ຢີ່ ດາໍ້ນຫ ງັຂອງບດັ EBT ຂອງທີ່ານເພອຍກົ ເລກ ຫ ໄປຍງັຫອໍ້ງການປະຈາ ທອໍ້ງຖ ນຂອງທີ່ານ ເພີ່ອຂ ບດັ ໃຫມີ່ . ຕອບກບັດວໍ້ ຍ STOP (ຢຸດເຊາົ) ເພອຢຸດເຊາົ",  # noqa too long
+            """ຂ ຄໍ້ ວາມການສໍ້ໂກງທອາດເປັນໄປໄດ ໍ້ DSHS: ພວກເຮາົໄດສໍ້ງັເກດເຫນັການສໂກງທີ່ອາດເປັນໄປໄດໃໍ້ນບນັຊຂ ອງທີ່ານ.
+            ໂທຫາ # ທ ຢີ່ ດາໍ້ນຫ ງັຂອງບດັ EBT ຂອງທີ່ານເພອຍກົ ເລກ ຫ ໄປຍງັຫອໍ້ງການປະຈາ ທອໍ້ງຖ ນຂອງທີ່ານ ເພີ່ອຂ
+            ບດັ ໃຫມີ່ . ຕອບກບັດວໍ້ ຍ STOP (ຢຸດເຊາົ) ເພອຢຸດເຊາົ""",
             True,
-        ),  # noqa too long # State of WA Lao
+        ),  # State of WA Lao
         (
-            "Fariin Khiyaamo Suurtogal ah DSHS: Waxaanu ka ogaanay khiyaamo suurtogal ah akoonkaaga. Wax # ee ku yaal xaga danbe ee kadadhka EBT si aad u joojisid ama u aadid xafiiska deegaanka uguna dalbatid a new one (mid cusub). Ku jawaab JOOJI si aad u joojisid",  # noqa too long
+            """Fariin Khiyaamo Suurtogal ah DSHS: Waxaanu ka ogaanay khiyaamo suurtogal ah akoonkaaga.
+            Wax # ee ku yaal xaga danbe ee kadadhka
+            EBT si aad u joojisid ama u aadid xafiiska deegaanka uguna dalbatid a new one (mid cusub).
+            Ku jawaab JOOJI si aad u joojisid""",
             True,
-        ),  # noqa too long # State of WA Somali
+        ),  # State of WA Somali
     ],
 )
 def test_sms_supporting_additional_languages(content, expected):

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1552,7 +1552,8 @@ def test_character_count_for_broadcast_templates(
     "msg, expected_sms_fragment_count",
     [
         (
-            "This is a very long long long long long long long long long long long long long long long long long long long long long long long long text message.",  # noqa
+            """This is a very long long long long long long long long long long
+             long long long long long long long long long long long long long long text message.""",
             1,
         ),
         ("This is a short message.", 1),

--- a/tests/test_timezones.py
+++ b/tests/test_timezones.py
@@ -14,7 +14,7 @@ from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
     ],
 )
 def test_utc_string_to_aware_gmt_datetime_rejects_bad_input(input_value):
-    with pytest.raises(Exception):  # noqa B017
+    with pytest.raises(BaseException):
         utc_string_to_aware_gmt_datetime(input_value)
 
 


### PR DESCRIPTION
## Description

The code had some # noqa tags, added to avoid having various quality checks fails.  A lot of these involved having lines that were too long.  I fixed most by added line breaks.  There are a few cases in the tests where I have not done this because the test is very sensitive to the line in question and the lines are up in the 'parameterize' section.  I don't feel any change to remove the # noqa for them is going to improve the readability or maintainability of the test.

Otherwise, it was either "don't do with pytest.raises(Exception)", or some weird lambda syntax, or even a bunch of # noqa tags in the production code that didn't seem to do anything at all.

## Security Considerations

N/A