### PR TITLE
Add Dependabot configuration to this repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset enables Dependabot in this repo, which we want turned on to keep our dependencies up-to-date.

This isn't enabled right now, but we should consider whether or not we want automatic merges for things that pass tests in the future.

A big thank you to @terrazoon and @samathad2023 for flagging this!

## Security Considerations

- We need Dependabot turned on to make sure our dependencies stay up to date.
