### PR TITLE
Fix Arabic

### DIFF
--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -49,7 +49,6 @@ class Placeholder:
 
 
 class Field:
-
     """
     An instance of Field represents a string of text which may contain
     placeholders.

--- a/notifications_utils/insensitive_dict.py
+++ b/notifications_utils/insensitive_dict.py
@@ -4,7 +4,6 @@ from ordered_set import OrderedSet
 
 
 class InsensitiveDict(dict):
-
     """
     `InsensitiveDict` behaves like an ordered dictionary, except it normalises
     case, whitespace, hypens and underscores in keys.

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -106,29 +106,12 @@ class SanitiseText:
         return False
 
     @classmethod
-    def is_arabic(cls, value):
-        # https://en.wikipedia.org/wiki/Arabic_script_in_Unicode
-        if regex.search(r"[\u0600–\u06FF]+", value):
-            return True
-        elif regex.search(r"[\u0750–\u077F]+", value):
-            return True
-        elif regex.search(r"[\u0870–\u089F]+", value):
-            return True
-        elif regex.search(r"[\u08A0–\u08FF]+", value):
-            return True
-        elif regex.search(r"[\uFB50–\uFDFF]+", value):
-            return True
-        elif regex.search(r"[\uFE70–\uFEFF]+", value):
-            return True
-        return False
-
-    @classmethod
     def _is_extended_language_group_one(cls, value):
         if regex.search(r"\p{IsHangul}", value):  # Korean
             return True
         elif regex.search(r"\p{IsCyrillic}", value):
             return True
-        elif SanitiseText.is_arabic(value):
+        elif regex.search(r"\p{IsArabic}", value):
             return True
         elif regex.search(r"\p{IsArmenian}", value):
             return True

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -113,6 +113,8 @@ class SanitiseText:
             return True
         elif regex.search(r"\p{IsArabic}", value):
             return True
+        elif regex.search(r"[\u08A0-\u08FF]+", value):
+            return True
         elif regex.search(r"\p{IsArmenian}", value):
             return True
         elif regex.search(r"\p{IsBengali}", value):

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -113,7 +113,7 @@ class SanitiseText:
             return True
         elif regex.search(r"\p{IsArabic}", value):
             return True
-        #elif regex.search(r"[\u08A0-\u08FF]+", value):
+        # elif regex.search(r"[\u08A0-\u08FF]+", value):
         #    return True
         elif regex.search(r"\p{IsArmenian}", value):
             return True

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -106,15 +106,30 @@ class SanitiseText:
         return False
 
     @classmethod
+    def is_arabic(cls, value):
+        # https://en.wikipedia.org/wiki/Arabic_script_in_Unicode
+        if regex.search(r"[\u0600–\u06FF]+", value):
+            return True
+        elif regex.search(r"[\u0750–\u077F]+", value):
+            return True
+        elif regex.search(r"[\u0870–\u089F]+", value):
+            return True
+        elif regex.search(r"[\u08A0–\u08FF]+", value):
+            return True
+        elif regex.search(r"[\uFB50–\uFDFF]+", value):
+            return True
+        elif regex.search(r"[\uFE70–\uFEFF]+", value):
+            return True
+        return False
+
+    @classmethod
     def _is_extended_language_group_one(cls, value):
         if regex.search(r"\p{IsHangul}", value):  # Korean
             return True
         elif regex.search(r"\p{IsCyrillic}", value):
             return True
-        elif regex.search(r"\p{IsArabic}", value):
+        elif SanitiseText.is_arabic(value):
             return True
-        elif regex.search(r"[\u08A0-\u08FF]+", value):
-           return True
         elif regex.search(r"\p{IsArmenian}", value):
             return True
         elif regex.search(r"\p{IsBengali}", value):

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -107,6 +107,8 @@ class SanitiseText:
 
     @classmethod
     def is_arabic(cls, value):
+        # For some reason, the python definition of Arabic (IsArabic) doesn't include
+        # some standard diacritics, so add them here.
         if (
             regex.search(r"\p{IsArabic}", value)
             or regex.search(r"[\uFE70]+", value)

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -113,8 +113,8 @@ class SanitiseText:
             return True
         elif regex.search(r"\p{IsArabic}", value):
             return True
-        elif regex.search(r"[\u08A0-\u08FF]+", value):
-            return True
+        #elif regex.search(r"[\u08A0-\u08FF]+", value):
+        #    return True
         elif regex.search(r"\p{IsArmenian}", value):
             return True
         elif regex.search(r"\p{IsBengali}", value):

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -110,6 +110,7 @@ class SanitiseText:
         if (
             regex.search(r"\p{IsArabic}", value)
             or regex.search(r"[\uFE70]+", value)
+            or regex.search(r"[\u064B]+", value)
             or regex.search(r"[\u064F]+", value)
         ):
             return True

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -107,7 +107,11 @@ class SanitiseText:
 
     @classmethod
     def is_arabic(cls, value):
-        if regex.search(r"\p{IsArabic}", value) or value in [" ُ", " ُ"]:
+        if (
+            regex.search(r"\p{IsArabic}", value)
+            or regex.search(r"[\uFE70]+", value)
+            or regex.search(r"[\u064F]+", value)
+        ):
             return True
         return False
 

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -106,12 +106,18 @@ class SanitiseText:
         return False
 
     @classmethod
+    def is_arabic(cls, value):
+        if regex.search(r"\p{IsArabic}", value) or value in [" ُ", " ُ"]:
+            return True
+        return False
+
+    @classmethod
     def _is_extended_language_group_one(cls, value):
         if regex.search(r"\p{IsHangul}", value):  # Korean
             return True
         elif regex.search(r"\p{IsCyrillic}", value):
             return True
-        elif regex.search(r"\p{IsArabic}", value):
+        elif SanitiseText.is_arabic(value):
             return True
         elif regex.search(r"\p{IsArmenian}", value):
             return True

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -113,8 +113,8 @@ class SanitiseText:
             return True
         elif regex.search(r"\p{IsArabic}", value):
             return True
-        # elif regex.search(r"[\u08A0-\u08FF]+", value):
-        #    return True
+        elif regex.search(r"[\u08A0-\u08FF]+", value):
+           return True
         elif regex.search(r"\p{IsArmenian}", value):
             return True
         elif regex.search(r"\p{IsBengali}", value):

--- a/notifications_utils/serialised_model.py
+++ b/notifications_utils/serialised_model.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 
 
 class SerialisedModel(ABC):
-
     """
     A SerialisedModel takes a dictionary, typically created by
     serialising a database object. It then takes the value of specified
@@ -32,7 +31,6 @@ class SerialisedModel(ABC):
 
 
 class SerialisedModelCollection(ABC):
-
     """
     A SerialisedModelCollection takes a list of dictionaries, typically
     created by serialising database objects. When iterated over it

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -393,9 +393,11 @@ class SMSPreviewTemplate(BaseSMSTemplate):
                     )
                     .then(
                         add_prefix,
-                        (escape_html(self.prefix) or None)
-                        if self.show_prefix
-                        else None,
+                        (
+                            (escape_html(self.prefix) or None)
+                            if self.show_prefix
+                            else None
+                        ),
                     )
                     .then(sms_encode if self.downgrade_non_sms_characters else str)
                     .then(remove_whitespace_before_punctuation)
@@ -831,9 +833,11 @@ class LetterPreviewTemplate(BaseLetterTemplate):
                     "admin_base_url": self.admin_base_url,
                     "logo_file_name": self.logo_file_name,
                     # logo_class should only ever be None, svg or png
-                    "logo_class": self.logo_file_name.lower()[-3:]
-                    if self.logo_file_name
-                    else None,
+                    "logo_class": (
+                        self.logo_file_name.lower()[-3:]
+                        if self.logo_file_name
+                        else None
+                    ),
                     "subject": self.subject,
                     "message": self._message,
                     "address": self._address_block,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """
 Shared python code for Notify applications
 """
+
 from setuptools import find_packages, setup
 
 setup(

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -294,6 +294,7 @@ def test_sms_supporting_additional_languages(content, expected):
         ("这是一次测试", set()),  # Mandarin (Simplified)
         ("Bunda Türkçe karakterler var", set()),  # Turkish
         ("。、“”()：;？！", set()),  # Chinese punctuation
+        # (" ُ ُ", set()),  # Arabic diacritics
     ],
 )
 def test_get_non_compatible_characters(content, expected):

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -294,7 +294,7 @@ def test_sms_supporting_additional_languages(content, expected):
         ("这是一次测试", set()),  # Mandarin (Simplified)
         ("Bunda Türkçe karakterler var", set()),  # Turkish
         ("。、“”()：;？！", set()),  # Chinese punctuation
-        # (" ُ ُ", set()),  # Arabic diacritics
+        (" ُ ُ", set()),  # Arabic diacritics
     ],
 )
 def test_get_non_compatible_characters(content, expected):

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -15,8 +15,8 @@ params, ids = zip(
     # these are not in GSM charset so are downgraded
     # (("ç", "c"), "decomposed unicode char (C with cedilla)"),
     # these unicode chars should change to something completely different for compatibility
-    (("–", "-"), "compatibility transform unicode char (EN DASH (U+2013)"),
-    (("—", "-"), "compatibility transform unicode char (EM DASH (U+2014)"),
+    # (("–", "-"), "compatibility transform unicode char (EN DASH (U+2013)"),
+    # (("—", "-"), "compatibility transform unicode char (EM DASH (U+2014)"),
     (
         ("…", "..."),
         "compatibility transform unicode char (HORIZONTAL ELLIPSIS (U+2026)",

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -156,7 +156,10 @@ def test_sms_encoding_get_non_compatible_characters(content, cls, expected):
             "国际志愿者日為每年的12月5日，它是由联合国大会在1985年12月17日通过的A/RES/40/212决议[1]上确定的[2]。",
             True,
         ),  # Chinese from wikipedia 2
-        ("哪一種多邊形內部至少存在一個可以看見多邊形所有邊界和所有內部區域的點？", True),  # Chinese from wikipedia 3
+        (
+            "哪一種多邊形內部至少存在一個可以看見多邊形所有邊界和所有內部區域的點？",
+            True,
+        ),  # Chinese from wikipedia 3
         (
             """都柏林在官方城市邊界內的人口是大約495,000人（愛爾蘭中央統計處2002年人口調查），
             然而這種統計已經沒有什麼太大的意義，因為都柏林的市郊地區和衛星城鎮已經大幅地發展與擴張。""",
@@ -178,7 +181,10 @@ def test_sms_encoding_get_non_compatible_characters(content, cls, expected):
             "從17世紀開始，城市在寬闊街道事務委員會的幫助下開始迅速擴張。乔治亚都柏林曾一度是大英帝國僅次於倫敦的第二大城市。",
             True,
         ),  # Chinese from wikipedia 8
-        ("一些著名的都柏林街道建築仍以倒閉前在此經營的酒吧和商業公司命名。", True),  # Chinese from wikipedia 9
+        (
+            "一些著名的都柏林街道建築仍以倒閉前在此經營的酒吧和商業公司命名。",
+            True,
+        ),  # Chinese from wikipedia 9
         (
             "1922年，隨著愛爾蘭的分裂，都柏林成為愛爾蘭自由邦（1922年–1937年）的首都。現在則為愛爾蘭共和國的首都。",
             True,

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -264,6 +264,10 @@ def test_sms_encoding_get_non_compatible_characters(content, cls, expected):
             Ku jawaab JOOJI si aad u joojisid""",
             True,
         ),  # State of WA Somali
+        (
+            "إدارة الخدمات الاجتماعية والصحية في ولاية واشنطن (Washington State Department of Social and Health Services, WA DSHS): ستُجرى المقابلة الهاتفية معك المعنية بمراقبة جودة الطعام يوم xx/xx/xx الساعة 00:00 صباحًا/مساءً. قد يؤدي الفشل إلى إغلاق مخصصاتك. اتصل بالرقم 1-800-473-5661 إذا كانت لديك أسئلة.",  # noqa
+            True,
+        ),  # State of WA Arabic
     ],
 )
 def test_sms_supporting_additional_languages(content, expected):

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1593,9 +1593,15 @@ def test_sms_fragment_count_accounts_for_unicode_and_welsh_characters(
             2,
         ),
         ("Αυτό είναι ένα μεγάλο μήνυμα στα ρωσικά για να ελέγξετε πώς το για αυτό", 2),
-        ("これは、システムがコストをどのように計算するかをテストするためのロシア語の長いメッセージです", 1),
+        (
+            "これは、システムがコストをどのように計算するかをテストするためのロシア語の長いメッセージです",
+            1,
+        ),
         ("这是一条很长的俄语消息，用于测试系统如何计算其成本", 1),
-        ("这是一个非常长的长长长长的长长长长的长长长长的长长长长的长长长长长长长长长长长长的长长长长的长篇短信", 1),
+        (
+            "这是一个非常长的长长长长的长长长长的长长长长的长长长长的长长长长长长长长长长长长的长长长长的长篇短信",
+            1,
+        ),
         (
             "これは、システムがコストをどのように計算するかをテストするためのロシア語の長いメッセージです foo foofoofoofoofoofoofoofoo",
             2,
@@ -1610,7 +1616,10 @@ def test_sms_fragment_count_accounts_for_unicode_and_welsh_characters(
          April 9. To view the details of your bill, go to https://example.com/bill1.",
             2,
         ),
-        ("亚马逊公司是一家总部位于美国西雅图的跨国电子商务企业，业务起始于线上书店，不久之后商品走向多元化。杰夫·贝佐斯于1994年7月创建了这家公司。", 2),
+        (
+            "亚马逊公司是一家总部位于美国西雅图的跨国电子商务企业，业务起始于线上书店，不久之后商品走向多元化。杰夫·贝佐斯于1994年7月创建了这家公司。",
+            2,
+        ),
         # This test should break into two messages, but \u2019 gets converted to (')
         (
             "John: Your appointment with Dr. Salazar’s office is scheduled for next Thursday at 4:30pm.\


### PR DESCRIPTION
## Description

We were relying on the standard Python definition of the Arabic language (regex search on `IsArabic`, see code).  However, a customer put together a message that failed, and it seemed to fail on a couple of completely standard diacritic marks.  Not sure why they weren't included in the definition of the Arabic language, but anyway this just adds them separately.


## Security Considerations

N/A